### PR TITLE
Update module specs to include longitudinal fields

### DIFF
--- a/inst/workflow/4_modules/report_kri_country.yaml
+++ b/inst/workflow/4_modules/report_kri_country.yaml
@@ -18,6 +18,16 @@ spec:
       type: numeric
     Flag:
       type: numeric
+    Numerator_Previous:
+      type: numeric
+    Denominator_Previous:
+      type: numeric
+    Metric_Previous:
+      type: numeric
+    Score_Previous:
+      type: numeric
+    Flag_Previous:
+      type: numeric
   Reporting_Metrics:
     _all:
       required: true

--- a/inst/workflow/4_modules/report_kri_site.yaml
+++ b/inst/workflow/4_modules/report_kri_site.yaml
@@ -18,6 +18,16 @@ spec:
       type: numeric
     Flag:
       type: numeric
+    Numerator_Previous:
+      type: numeric
+    Denominator_Previous:
+      type: numeric
+    Metric_Previous:
+      type: numeric
+    Score_Previous:
+      type: numeric
+    Flag_Previous:
+      type: numeric
   Reporting_Metrics:
     _all:
       required: true


### PR DESCRIPTION
Adding `*_Previous` fields to the module yaml specs in order to ensure proper typing in the pipeline. A more robust solution is coming in the form of this [gsm.mapping issue](https://github.com/Gilead-BioStats/gsm.mapping/issues/79) 

Closes #99 