### PR TITLE
gsm.kri v1.2.2 release candidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gsm.kri
 Title: Good Statistical Monitoring KRIs
-Version: 1.2.1
+Version: 1.2.2
 Authors@R: c(
     person("Jeremy", "Wildfire", , "jwildfire@gmail.com", role = c("aut", "cre")),
     person("Laura", "Maxwell", , "lkmaxwell23@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gsm.kri 1.2.2
+
+This patch release fixes a bug in `Report_KRI.Rmd` that produced an error in LaTeX compilation of the report output.
+
 # gsm.kri 1.2.1
 
 This patch release addresses changes to an `.rda` object updated in `gsm.core` v1.1.3.

--- a/man/Report_KRI.Rd
+++ b/man/Report_KRI.Rd
@@ -63,7 +63,11 @@ lChartsSite <- MakeCharts(
 strOutputFile <- "StandardSiteReport.html"
 kri_report_path <- Report_KRI(
   lCharts = lChartsSite,
-  dfResults = gsm.core::reportingResults,
+  dfResults = gsm.core::reportingResults \%>\%
+    FilterByLatestSnapshotDate() \%>\%
+    gsm.reporting::CalculateChange(
+      gsm.core::reportingResults
+    ),
   dfMetrics = gsm.core::reportingMetrics,
   dfGroups = gsm.core::reportingGroups,
   strOutputFile = strOutputFile
@@ -80,7 +84,11 @@ lChartsCountry <- MakeCharts(
 strOutputFile <- "StandardCountryReport.html"
 kri_report_path <- Report_KRI(
   lCharts = lChartsCountry,
-  dfResults = gsm.core::reportingResults_country,
+  dfResults = gsm.core::reportingResults_country \%>\%
+    FilterByLatestSnapshotDate() \%>\%
+    gsm.reporting::CalculateChange(
+      gsm.core::reportingResults_country
+    ),
   dfMetrics = gsm.core::reportingMetrics_country,
   dfGroups = gsm.core::reportingGroups_country,
   strOutputFile = strOutputFile


### PR DESCRIPTION
# gsm.kri 1.2.2

This patch release fixes a bug in `Report_KRI.Rmd` that produced an error in LaTeX compilation of the report output.

Part of the Q2.1 patch releases documented [here](https://gileadconnect.sharepoint.com/:x:/r/teams/RiskBasedMonitoringInitiative/Shared%20Documents/Analytics_Technology/Analytics%20Working%20Groups/Analytics%20WG%20Tracker.xlsx?d=w8bc03988c6764d66ba2b769648a0f496&csf=1&web=1&e=FAjJCY)