### PR TITLE
Issue #190: Reduce KRI report render time via shared widget payloads

### DIFF
--- a/R/Visualize_Metric.R
+++ b/R/Visualize_Metric.R
@@ -154,12 +154,11 @@ Visualize_Metric <- function(
     lCharts$scatterPlot <- do.call(
       "Widget_ScatterPlot",
       list(
-        dfResults = NULL,
+        dfResults = dfResults_latest,
         lMetric = lMetric,
         dfGroups = dfGroups,
-        dfBounds = NULL,
+        dfBounds = dfBounds_latest,
         strSharedPayloadKey = strSharedPayloadKeyLatest,
-        vSharedFields = c("dfResults", "lMetric", "dfGroups", "dfBounds"),
         bDebug = bDebug,
         ...
       )
@@ -168,12 +167,11 @@ Visualize_Metric <- function(
     lCharts$barChart <- do.call(
       "Widget_BarChart",
       list(
-        dfResults = NULL,
+        dfResults = dfResults_latest,
         lMetric = lMetric,
         dfGroups = dfGroups,
         vThreshold = vThreshold,
         strSharedPayloadKey = strSharedPayloadKeyLatest,
-        vSharedFields = c("dfResults", "lMetric", "dfGroups", "vThreshold"),
         bDebug = bDebug,
         ...
       )
@@ -211,12 +209,11 @@ Visualize_Metric <- function(
     lCharts$timeSeries <- do.call(
       "Widget_TimeSeries",
       list(
-        dfResults = NULL,
+        dfResults = dfResults,
         lMetric = lMetric,
         dfGroups = dfGroups,
         vThreshold = vThreshold,
         strSharedPayloadKey = strSharedPayloadKeyAll,
-        vSharedFields = c("dfResults", "lMetric", "dfGroups", "vThreshold"),
         bDebug = bDebug,
         ...
       )

--- a/R/Visualize_Metric.R
+++ b/R/Visualize_Metric.R
@@ -118,6 +118,15 @@ Visualize_Metric <- function(
 
   # Cross-sectional Charts using most recent snapshot ------------------------
   lCharts <- list()
+  strMetricKey <- if (!is.null(strMetricID)) {
+    strMetricID
+  } else {
+    unique(dfResults$MetricID)[1]
+  }
+
+  strSharedPayloadKeyLatest <- paste0(strMetricKey, "::latest")
+  strSharedPayloadKeyAll <- paste0(strMetricKey, "::all")
+
   dfResults_latest <- FilterByLatestSnapshotDate(dfResults, strSnapshotDate)
   if (is.null(dfBounds)) {
     dfBounds_latest <- NULL
@@ -131,13 +140,26 @@ Visualize_Metric <- function(
       message = "No data found for specified snapshot date: {strSnapshotDate}. No charts will be generated."
     )
   } else {
-    lCharts$scatterPlot <- do.call(
-      "Widget_ScatterPlot",
+    lSharedPayloadRegistry <- list(
       list(
         dfResults = dfResults_latest,
         lMetric = lMetric,
         dfGroups = dfGroups,
         dfBounds = dfBounds_latest,
+        vThreshold = vThreshold
+      )
+    )
+    names(lSharedPayloadRegistry) <- strSharedPayloadKeyLatest
+
+    lCharts$scatterPlot <- do.call(
+      "Widget_ScatterPlot",
+      list(
+        dfResults = NULL,
+        lMetric = lMetric,
+        dfGroups = dfGroups,
+        dfBounds = NULL,
+        strSharedPayloadKey = strSharedPayloadKeyLatest,
+        vSharedFields = c("dfResults", "lMetric", "dfGroups", "dfBounds"),
         bDebug = bDebug,
         ...
       )
@@ -146,10 +168,12 @@ Visualize_Metric <- function(
     lCharts$barChart <- do.call(
       "Widget_BarChart",
       list(
-        dfResults = dfResults_latest,
+        dfResults = NULL,
         lMetric = lMetric,
         dfGroups = dfGroups,
         vThreshold = vThreshold,
+        strSharedPayloadKey = strSharedPayloadKeyLatest,
+        vSharedFields = c("dfResults", "lMetric", "dfGroups", "vThreshold"),
         bDebug = bDebug,
         ...
       )
@@ -173,17 +197,34 @@ Visualize_Metric <- function(
       cli_detail = "alert_info"
     )
   } else {
+    if (!exists("lSharedPayloadRegistry")) {
+      lSharedPayloadRegistry <- list()
+    }
+
+    lSharedPayloadRegistry[[strSharedPayloadKeyAll]] <- list(
+      dfResults = dfResults,
+      lMetric = lMetric,
+      dfGroups = dfGroups,
+      vThreshold = vThreshold
+    )
+
     lCharts$timeSeries <- do.call(
       "Widget_TimeSeries",
       list(
-        dfResults = dfResults,
+        dfResults = NULL,
         lMetric = lMetric,
         dfGroups = dfGroups,
         vThreshold = vThreshold,
+        strSharedPayloadKey = strSharedPayloadKeyAll,
+        vSharedFields = c("dfResults", "lMetric", "dfGroups", "vThreshold"),
         bDebug = bDebug,
         ...
       )
     )
+  }
+
+  if (exists("lSharedPayloadRegistry")) {
+    base::attr(lCharts, "shared_payload_registry") <- lSharedPayloadRegistry
   }
 
   return(lCharts)

--- a/R/Widget_BarChart.R
+++ b/R/Widget_BarChart.R
@@ -37,6 +37,8 @@ Widget_BarChart <- function(
   lMetric = NULL,
   dfGroups = NULL,
   vThreshold = NULL,
+  strSharedPayloadKey = NULL,
+  vSharedFields = NULL,
   strOutcome = "Score",
   vOutcomeOptions = c("Score", "Metric", "Numerator"),
   bAddGroupSelect = TRUE,
@@ -49,7 +51,7 @@ Widget_BarChart <- function(
   ...
 ) {
   gsm.core::stop_if(
-    cnd = !is.data.frame(dfResults),
+    cnd = !(is.data.frame(dfResults) || (!is.null(strSharedPayloadKey) && is.null(dfResults))),
     message = "dfResults is not a data.frame"
   )
   gsm.core::stop_if(
@@ -59,6 +61,18 @@ Widget_BarChart <- function(
   gsm.core::stop_if(
     cnd = !(is.null(dfGroups) || is.data.frame(dfGroups)),
     message = "dfGroups is not a data.frame"
+  )
+  gsm.core::stop_if(
+    cnd = !(is.null(strSharedPayloadKey) || is.character(strSharedPayloadKey)),
+    message = "strSharedPayloadKey is not a character"
+  )
+  gsm.core::stop_if(
+    cnd = !is.null(strSharedPayloadKey) && length(strSharedPayloadKey) != 1,
+    message = "strSharedPayloadKey must be length 1"
+  )
+  gsm.core::stop_if(
+    cnd = !(is.null(vSharedFields) || is.character(vSharedFields)),
+    message = "vSharedFields is not a character vector"
   )
   gsm.core::stop_if(
     cnd = !length(strOutcome) == 1,
@@ -125,6 +139,15 @@ Widget_BarChart <- function(
     strShinyGroupSelectID = strShinyGroupSelectID,
     bDebug = bDebug
   )
+
+  if (!is.null(strSharedPayloadKey)) {
+    lInput$strSharedPayloadKey <- strSharedPayloadKey
+  }
+
+  if (!is.null(vSharedFields)) {
+    vSharedFields <- intersect(vSharedFields, names(lInput))
+    lInput[vSharedFields] <- list(NULL)
+  }
 
   # create widget
   lWidget <- htmlwidgets::createWidget(

--- a/R/Widget_BarChart.R
+++ b/R/Widget_BarChart.R
@@ -8,6 +8,8 @@
 #'
 #' @inheritParams shared-params
 #' @param vThreshold `numeric` Threshold values.
+#' @param strSharedPayloadKey `character` Optional key used to resolve shared widget payloads.
+#' @param vSharedFields `character` Optional fields to remove from widget payload and resolve via `strSharedPayloadKey`.
 #' @param strOutcome `character` Outcome variable. Default: 'Score'.
 #' @param bAddGroupSelect `logical` Add a dropdown to highlight sites? Default: `TRUE`.
 #' @param strShinyGroupSelectID `character` Element ID of group select in Shiny context. Default: `'GroupID'`.

--- a/R/Widget_ScatterPlot.R
+++ b/R/Widget_ScatterPlot.R
@@ -7,6 +7,8 @@
 #' on the x-axis and the numerator on the y-axis.
 #'
 #' @inheritParams shared-params
+#' @param strSharedPayloadKey `character` Optional key used to resolve shared widget payloads.
+#' @param vSharedFields `character` Optional fields to remove from widget payload and resolve via `strSharedPayloadKey`.
 #' @param bAddGroupSelect `logical` Add a dropdown to highlight sites? Default: `TRUE`.
 #' @param strShinyGroupSelectID `character` Element ID of group select in Shiny context. Default: `'GroupID'`.
 #' @param ... `any` Additional chart configuration settings.

--- a/R/Widget_ScatterPlot.R
+++ b/R/Widget_ScatterPlot.R
@@ -37,6 +37,8 @@ Widget_ScatterPlot <- function(
   lMetric = NULL,
   dfGroups = NULL,
   dfBounds = NULL,
+  strSharedPayloadKey = NULL,
+  vSharedFields = NULL,
   bAddGroupSelect = TRUE,
   strShinyGroupSelectID = "GroupID",
   strOutputLabel = paste0(
@@ -47,7 +49,7 @@ Widget_ScatterPlot <- function(
   ...
 ) {
   gsm.core::stop_if(
-    cnd = !is.data.frame(dfResults),
+    cnd = !(is.data.frame(dfResults) || (!is.null(strSharedPayloadKey) && is.null(dfResults))),
     "dfResults is not a data.frame"
   )
   gsm.core::stop_if(
@@ -61,6 +63,18 @@ Widget_ScatterPlot <- function(
   gsm.core::stop_if(
     cnd = !(is.null(dfBounds) || is.data.frame(dfBounds)),
     "dfBounds is not a data.frame"
+  )
+  gsm.core::stop_if(
+    cnd = !(is.null(strSharedPayloadKey) || is.character(strSharedPayloadKey)),
+    "strSharedPayloadKey is not a character"
+  )
+  gsm.core::stop_if(
+    cnd = !is.null(strSharedPayloadKey) && length(strSharedPayloadKey) != 1,
+    "strSharedPayloadKey must be length 1"
+  )
+  gsm.core::stop_if(
+    cnd = !(is.null(vSharedFields) || is.character(vSharedFields)),
+    "vSharedFields is not a character vector"
   )
   gsm.core::stop_if(
     cnd = !is.logical(bAddGroupSelect),
@@ -97,6 +111,15 @@ Widget_ScatterPlot <- function(
     ),
     bDebug = bDebug
   )
+
+  if (!is.null(strSharedPayloadKey)) {
+    lWidgetInput$strSharedPayloadKey <- strSharedPayloadKey
+  }
+
+  if (!is.null(vSharedFields)) {
+    vSharedFields <- intersect(vSharedFields, names(lWidgetInput))
+    lWidgetInput[vSharedFields] <- list(NULL)
+  }
 
   # create widget
   lWidget <- htmlwidgets::createWidget(

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -8,6 +8,8 @@
 #'
 #' @inheritParams shared-params
 #' @param vThreshold `numeric` Threshold value(s).
+#' @param strSharedPayloadKey `character` Optional key used to resolve shared widget payloads.
+#' @param vSharedFields `character` Optional fields to remove from widget payload and resolve via `strSharedPayloadKey`.
 #' @param strOutcome `character` Outcome variable. Default: 'Score'.
 #' @param bAddGroupSelect `logical` Add a dropdown to highlight sites? Default: `TRUE`.
 #' @param strShinyGroupSelectID `character` Element ID of group select in Shiny context. Default: `'GroupID'`.

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -36,6 +36,8 @@ Widget_TimeSeries <- function(
   lMetric = NULL,
   dfGroups = NULL,
   vThreshold = NULL,
+  strSharedPayloadKey = NULL,
+  vSharedFields = NULL,
   strOutcome = "Score",
   vOutcomeOptions = c("Score", "Metric", "Numerator"),
   bAddGroupSelect = TRUE,
@@ -48,7 +50,7 @@ Widget_TimeSeries <- function(
   ...
 ) {
   gsm.core::stop_if(
-    cnd = !is.data.frame(dfResults),
+    cnd = !(is.data.frame(dfResults) || (!is.null(strSharedPayloadKey) && is.null(dfResults))),
     "dfResults is not a data.frame"
   )
   gsm.core::stop_if(
@@ -58,6 +60,18 @@ Widget_TimeSeries <- function(
   gsm.core::stop_if(
     cnd = !(is.null(dfGroups) || is.data.frame(dfGroups)),
     "dfGroups is not a data.frame"
+  )
+  gsm.core::stop_if(
+    cnd = !(is.null(strSharedPayloadKey) || is.character(strSharedPayloadKey)),
+    "strSharedPayloadKey is not a character"
+  )
+  gsm.core::stop_if(
+    cnd = !is.null(strSharedPayloadKey) && length(strSharedPayloadKey) != 1,
+    "strSharedPayloadKey must be length 1"
+  )
+  gsm.core::stop_if(
+    cnd = !(is.null(vSharedFields) || is.character(vSharedFields)),
+    "vSharedFields is not a character vector"
   )
   gsm.core::stop_if(
     cnd = length(strOutcome) != 1,
@@ -121,6 +135,15 @@ Widget_TimeSeries <- function(
     strShinyGroupSelectID = strShinyGroupSelectID,
     bDebug = bDebug
   )
+
+  if (!is.null(strSharedPayloadKey)) {
+    lInput$strSharedPayloadKey <- strSharedPayloadKey
+  }
+
+  if (!is.null(vSharedFields)) {
+    vSharedFields <- intersect(vSharedFields, names(lInput))
+    lInput[vSharedFields] <- list(NULL)
+  }
 
   # create widget
   lWidget <- htmlwidgets::createWidget(

--- a/inst/htmlwidgets/Widget_BarChart.js
+++ b/inst/htmlwidgets/Widget_BarChart.js
@@ -4,6 +4,8 @@ HTMLWidgets.widget({
     factory: function(el, width, height) {
         return {
             renderValue: function(input) {
+                input = resolveSharedWidgetInput(input);
+
                 if (input.bDebug)
                     console.log(input);
 

--- a/inst/htmlwidgets/Widget_BarChart.yaml
+++ b/inst/htmlwidgets/Widget_BarChart.yaml
@@ -24,6 +24,10 @@ dependencies:
     version: 1.0.0
     src: 'htmlwidgets/lib'
     script: 'getCountries.js'
+  - name: resolveSharedWidgetInput
+    version: 1.0.0
+    src: 'htmlwidgets/lib'
+    script: 'resolveSharedWidgetInput.js'
   - name: addOutcomeSelect
     version: 1.0.0
     src: 'htmlwidgets/lib'

--- a/inst/htmlwidgets/Widget_ScatterPlot.js
+++ b/inst/htmlwidgets/Widget_ScatterPlot.js
@@ -4,6 +4,8 @@ HTMLWidgets.widget({
     factory: function(el, width, height) {
         return {
             renderValue: function(input) {
+                input = resolveSharedWidgetInput(input);
+
                 if (input.bDebug)
                     console.log(input);
 

--- a/inst/htmlwidgets/Widget_ScatterPlot.yaml
+++ b/inst/htmlwidgets/Widget_ScatterPlot.yaml
@@ -24,3 +24,7 @@ dependencies:
     version: 1.0.0
     src: 'htmlwidgets/lib'
     script: 'getCountries.js'
+  - name: resolveSharedWidgetInput
+    version: 1.0.0
+    src: 'htmlwidgets/lib'
+    script: 'resolveSharedWidgetInput.js'

--- a/inst/htmlwidgets/Widget_TimeSeries.js
+++ b/inst/htmlwidgets/Widget_TimeSeries.js
@@ -4,6 +4,8 @@ HTMLWidgets.widget({
     factory: function(el, width, height) {
         return {
             renderValue: function(input) {
+                input = resolveSharedWidgetInput(input);
+
                 if (input.bDebug)
                     console.log(input);
 

--- a/inst/htmlwidgets/Widget_TimeSeries.yaml
+++ b/inst/htmlwidgets/Widget_TimeSeries.yaml
@@ -24,6 +24,10 @@ dependencies:
     version: 1.0.0
     src: 'htmlwidgets/lib'
     script: 'getCountries.js'
+  - name: resolveSharedWidgetInput
+    version: 1.0.0
+    src: 'htmlwidgets/lib'
+    script: 'resolveSharedWidgetInput.js'
   - name: addOutcomeSelect
     version: 1.0.0
     src: 'htmlwidgets/lib'

--- a/inst/htmlwidgets/lib/resolveSharedWidgetInput.js
+++ b/inst/htmlwidgets/lib/resolveSharedWidgetInput.js
@@ -6,7 +6,18 @@ const resolveSharedWidgetInput = function(input) {
     }
 
     window.__gsmKriSharedPayloadRegistry = window.__gsmKriSharedPayloadRegistry || {};
-    const sharedPayload = window.__gsmKriSharedPayloadRegistry[ sharedPayloadKey ] || {};
+    const registry = window.__gsmKriSharedPayloadRegistry;
+
+    if (!Object.prototype.hasOwnProperty.call(registry, sharedPayloadKey)) {
+        console.warn(
+            'resolveSharedWidgetInput: shared payload key "' +
+            sharedPayloadKey +
+            '" not found in window.__gsmKriSharedPayloadRegistry; using original input without shared payload.'
+        );
+        return input;
+    }
+
+    const sharedPayload = registry[ sharedPayloadKey ] || {};
 
     const output = { ...input };
 

--- a/inst/htmlwidgets/lib/resolveSharedWidgetInput.js
+++ b/inst/htmlwidgets/lib/resolveSharedWidgetInput.js
@@ -1,0 +1,20 @@
+const resolveSharedWidgetInput = function(input) {
+    const sharedPayloadKey = input.strSharedPayloadKey;
+
+    if (!sharedPayloadKey) {
+        return input;
+    }
+
+    window.__gsmKriSharedPayloadRegistry = window.__gsmKriSharedPayloadRegistry || {};
+    const sharedPayload = window.__gsmKriSharedPayloadRegistry[ sharedPayloadKey ] || {};
+
+    const output = { ...input };
+
+    Object.keys(sharedPayload).forEach(key => {
+        if (output[ key ] === null || typeof output[ key ] === 'undefined') {
+            output[ key ] = sharedPayload[ key ];
+        }
+    });
+
+    return output;
+};

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -155,6 +155,33 @@ for (i in vMetrics) {
   lMetric <- params$dfMetrics %>% dplyr::filter(MetricID == i) %>% as.list
   lMetricCharts <- params$lCharts[[lMetric$MetricID]]
 
+  lMetricCharts <- purrr::map(
+    lMetricCharts,
+    ~ {
+      lChart <- .x
+      strSharedPayloadKey <- lChart$x$strSharedPayloadKey
+
+      if (!is.null(strSharedPayloadKey)) {
+        vSharedFields <- intersect(
+          c("dfResults", "lMetric", "dfGroups", "dfBounds", "vThreshold"),
+          names(lChart$x)
+        )
+
+        lChart$x[vSharedFields] <- purrr::map(
+          vSharedFields,
+          ~ jsonlite::toJSON(
+            NULL,
+            null = "null",
+            na = "string",
+            auto_unbox = TRUE
+          )
+        )
+      }
+
+      lChart
+    }
+  )
+
   lSharedPayloadRegistry <- attr(lMetricCharts, "shared_payload_registry", exact = TRUE)
   if (!is.null(lSharedPayloadRegistry) && length(lSharedPayloadRegistry) > 0) {
     strSharedPayloadJSON <- jsonlite::toJSON(
@@ -163,6 +190,8 @@ for (i in vMetrics) {
       na = "string",
       auto_unbox = TRUE
     )
+    strSharedPayloadJSON <- gsub("</", "<\\/", strSharedPayloadJSON, fixed = TRUE)
+    strSharedPayloadJSON <- gsub("<", "\\\\u003c", strSharedPayloadJSON, fixed = TRUE)
 
     print(
       htmltools::tags$script(

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -153,11 +153,35 @@ vMetrics <- unique(params$dfResults$MetricID)[grep("srs", unique(params$dfResult
 
 for (i in vMetrics) {
   lMetric <- params$dfMetrics %>% dplyr::filter(MetricID == i) %>% as.list
+  lMetricCharts <- params$lCharts[[lMetric$MetricID]]
+
+  lSharedPayloadRegistry <- attr(lMetricCharts, "shared_payload_registry", exact = TRUE)
+  if (!is.null(lSharedPayloadRegistry) && length(lSharedPayloadRegistry) > 0) {
+    strSharedPayloadJSON <- jsonlite::toJSON(
+      lSharedPayloadRegistry,
+      null = "null",
+      na = "string",
+      auto_unbox = TRUE
+    )
+
+    print(
+      htmltools::tags$script(
+        htmltools::HTML(
+          paste0(
+            "window.__gsmKriSharedPayloadRegistry = window.__gsmKriSharedPayloadRegistry || {};",
+            "Object.assign(window.__gsmKriSharedPayloadRegistry, ",
+            strSharedPayloadJSON,
+            ");"
+          )
+        )
+      )
+    )
+  }
 
   print(htmltools::h3(lMetric$Metric))
   
   Report_MetricCharts(
-    lCharts = params$lCharts[[lMetric$MetricID]],
+    lCharts = lMetricCharts,
     strMetricID = lMetric$MetricID
   )
   

--- a/inst/workflow/2_metrics/cou0001.yaml
+++ b/inst/workflow/2_metrics/cou0001.yaml
@@ -7,8 +7,8 @@ meta:
   Numerator: Adverse Events
   Denominator: Days on Study
   Model: Normal Approximation
-  AnalysisType: rate
   Score: Adjusted Z-Score
+  AnalysisType: rate
   Threshold: -2,-1,2,3
   Flag: "-2,-1,0,1,2"
   AccrualThreshold: 30
@@ -51,7 +51,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0001.yaml
+++ b/inst/workflow/2_metrics/cou0001.yaml
@@ -10,6 +10,7 @@ meta:
   AnalysisType: rate
   Score: Adjusted Z-Score
   Threshold: -2,-1,2,3
+  Flag: "-2,-1,0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Denominator
 spec:
@@ -28,6 +29,11 @@ steps:
     name: gsm.core::ParseThreshold
     params:
       strThreshold: Threshold
+  - output: vFlag
+    name: gsm.core::ParseThreshold
+    params:
+      strThreshold: Flag
+      bSort: false
   - output: Analysis_Input
     name: gsm.core::Input_Rate
     params:
@@ -50,10 +56,11 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold
+      vFlag: vFlag
       nAccrualThreshold: AccrualThreshold
       strAccrualMetric: AccrualMetric
   - output: Analysis_Summary

--- a/inst/workflow/2_metrics/cou0002.yaml
+++ b/inst/workflow/2_metrics/cou0002.yaml
@@ -37,7 +37,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_SAE
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_AE
       strQuery: "SELECT * FROM df WHERE aeser = 'Y'"
@@ -58,7 +58,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0002.yaml
+++ b/inst/workflow/2_metrics/cou0002.yaml
@@ -10,6 +10,7 @@ meta:
   Score: Adjusted Z-Score
   AnalysisType: rate
   Threshold: -2,-1,2,3
+  Flag: "-2,-1,0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Denominator
 spec:
@@ -30,6 +31,11 @@ steps:
     name: gsm.core::ParseThreshold
     params:
       strThreshold: Threshold
+  - output: vFlag
+    name: gsm.core::ParseThreshold
+    params:
+      strThreshold: Flag
+      bSort: false
   - output: Temp_SAE
     name: RunQuery
     params:
@@ -57,10 +63,11 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold
+      vFlag: vFlag
       nAccrualThreshold: AccrualThreshold
       strAccrualMetric: AccrualMetric
   - output: Analysis_Summary

--- a/inst/workflow/2_metrics/cou0003.yaml
+++ b/inst/workflow/2_metrics/cou0003.yaml
@@ -37,7 +37,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_NONIMPORTANT
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_PD
       strQuery: "SELECT * FROM df WHERE deemedimportant = 'No'"
@@ -58,7 +58,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0003.yaml
+++ b/inst/workflow/2_metrics/cou0003.yaml
@@ -10,6 +10,7 @@ meta:
   Score: Adjusted Z-Score
   AnalysisType: rate
   Threshold: -3,-2,2,3
+  Flag: "-2,-1,0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Denominator
 spec:
@@ -30,6 +31,11 @@ steps:
     name: gsm.core::ParseThreshold
     params:
       strThreshold: Threshold
+  - output: vFlag
+    name: gsm.core::ParseThreshold
+    params:
+      strThreshold: Flag
+      bSort: false
   - output: Temp_NONIMPORTANT
     name: RunQuery
     params:
@@ -57,10 +63,11 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold
+      vFlag: vFlag
       nAccrualThreshold: AccrualThreshold
       strAccrualMetric: AccrualMetric
   - output: Analysis_Summary

--- a/inst/workflow/2_metrics/cou0004.yaml
+++ b/inst/workflow/2_metrics/cou0004.yaml
@@ -10,6 +10,7 @@ meta:
   Score: Adjusted Z-Score
   AnalysisType: rate
   Threshold: -3,-2,2,3
+  Flag: "-2,-1,0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Denominator
 spec:
@@ -30,6 +31,11 @@ steps:
     name: gsm.core::ParseThreshold
     params:
       strThreshold: Threshold
+  - output: vFlag
+    name: gsm.core::ParseThreshold
+    params:
+      strThreshold: Flag
+      bSort: false
   - output: Temp_Important
     name: RunQuery
     params:
@@ -57,10 +63,11 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold
+      vFlag: vFlag
       nAccrualThreshold: AccrualThreshold
       strAccrualMetric: AccrualMetric
   - output: Analysis_Summary

--- a/inst/workflow/2_metrics/cou0004.yaml
+++ b/inst/workflow/2_metrics/cou0004.yaml
@@ -37,7 +37,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_Important
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_PD
       strQuery: "SELECT * FROM df WHERE deemedimportant = 'Yes'"
@@ -58,7 +58,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0005.yaml
+++ b/inst/workflow/2_metrics/cou0005.yaml
@@ -34,12 +34,12 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_ABNORMAL
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_LB
       strQuery: "SELECT * FROM df WHERE toxgrg_nsv IN ('3', '4')"
   - output: Temp_LB
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_LB
       strQuery: "SELECT * FROM df WHERE toxgrg_nsv IN ('0', '1', '2', '3', '4')"
@@ -59,7 +59,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0005.yaml
+++ b/inst/workflow/2_metrics/cou0005.yaml
@@ -64,7 +64,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0006.yaml
+++ b/inst/workflow/2_metrics/cou0006.yaml
@@ -59,7 +59,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0006.yaml
+++ b/inst/workflow/2_metrics/cou0006.yaml
@@ -34,7 +34,7 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_DROPOUT
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_STUDCOMP
       strQuery: "SELECT * FROM df WHERE compyn = 'N'"
@@ -54,7 +54,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0007.yaml
+++ b/inst/workflow/2_metrics/cou0007.yaml
@@ -24,8 +24,6 @@ spec:
       type: character
     sdrgyn:
       type: character
-    phase:
-      type: character
 steps:
   - output: vThreshold
     name: gsm.core::ParseThreshold
@@ -36,7 +34,7 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_DISCONTINUED
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_SDRGCOMP
       strQuery: "SELECT DISTINCT subjid FROM df WHERE sdrgyn = 'N'"
@@ -56,7 +54,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0007.yaml
+++ b/inst/workflow/2_metrics/cou0007.yaml
@@ -61,7 +61,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0008.yaml
+++ b/inst/workflow/2_metrics/cou0008.yaml
@@ -37,7 +37,7 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_QUERY
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_QUERY
       strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed')"
@@ -57,7 +57,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0008.yaml
+++ b/inst/workflow/2_metrics/cou0008.yaml
@@ -62,7 +62,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0009.yaml
+++ b/inst/workflow/2_metrics/cou0009.yaml
@@ -66,7 +66,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0009.yaml
+++ b/inst/workflow/2_metrics/cou0009.yaml
@@ -36,12 +36,12 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_OLDQUERY
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_QUERY
       strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed') AND queryage > 30"
   - output: Temp_QUERY
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_QUERY
       strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed')"
@@ -61,7 +61,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0010.yaml
+++ b/inst/workflow/2_metrics/cou0010.yaml
@@ -34,7 +34,7 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_LAG
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_DATAENT
       strQuery: "SELECT * FROM df WHERE data_entry_lag > 10"
@@ -54,7 +54,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0010.yaml
+++ b/inst/workflow/2_metrics/cou0010.yaml
@@ -59,7 +59,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0011.yaml
+++ b/inst/workflow/2_metrics/cou0011.yaml
@@ -34,7 +34,7 @@ steps:
     params:
       strThreshold: Flag
   - output: Temp_CHANGED
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_DATACHG
       strQuery: "SELECT * FROM df WHERE n_changes > 0"
@@ -54,7 +54,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0011.yaml
+++ b/inst/workflow/2_metrics/cou0011.yaml
@@ -59,7 +59,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/cou0012.yaml
+++ b/inst/workflow/2_metrics/cou0012.yaml
@@ -32,7 +32,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_SCREENED
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_ENROLL
       strQuery: "SELECT * FROM df WHERE enrollyn = 'N'"
@@ -52,7 +52,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/cou0012.yaml
+++ b/inst/workflow/2_metrics/cou0012.yaml
@@ -10,6 +10,7 @@ meta:
   Score: Adjusted Z-Score
   AnalysisType: binary
   Threshold: -3,-2,2,3
+  Flag: "-2,-1,0,1,2"
   AccrualThreshold: 3
   AccrualMetric: Denominator
 spec:
@@ -25,6 +26,11 @@ steps:
     name: gsm.core::ParseThreshold
     params:
       strThreshold: Threshold
+  - output: vFlag
+    name: gsm.core::ParseThreshold
+    params:
+      strThreshold: Flag
+      bSort: false
   - output: Temp_SCREENED
     name: RunQuery
     params:
@@ -51,10 +57,11 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold
+      vFlag: vFlag
       nAccrualThreshold: AccrualThreshold
       strAccrualMetric: AccrualMetric
   - output: Analysis_Summary

--- a/inst/workflow/2_metrics/cou0013.yaml
+++ b/inst/workflow/2_metrics/cou0013.yaml
@@ -11,8 +11,8 @@ meta:
   AnalysisType: identity
   Threshold: "0.9,0.85"
   Flag: "-2,-1,0"
-  AccrualMetric: Difference
   AccrualThreshold: 3
+  AccrualMetric: Difference
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0014.yaml
+++ b/inst/workflow/2_metrics/cou0014.yaml
@@ -8,30 +8,20 @@ meta:
   Denominator: Number of subjects enrolled
   Model: Identity (Numerator)
   Score: Ineligible Participants
-  ScoreCol: Numerator
   AnalysisType: identity
-  Threshold: "1.5, 2.5"
+  Threshold: "1.5,2.5"
   Flag: "0,1,2"
   RiskScoreWeight: "0,8,16"
   AccrualThreshold: 3
   AccrualMetric: Denominator
+  ScoreCol: Numerator
 spec:
   Mapped_EXCLUSION:
-    subjid:
-      type: character
     subjectid:
-      type: character
-    Source:
-      type: character
-    studyid:
-      type: character
-    invid:
       type: character
     country:
       type: character
-    eligibility_criteria:
-      type: character
-    ie_violation:
+    Source:
       type: character
 steps:
   - output: vThreshold
@@ -71,7 +61,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_Identity
+    name: gsm.core::Analyze_Identity
     params:
       dfTransformed: Analysis_Transformed
       strValueCol: ScoreCol

--- a/inst/workflow/2_metrics/kri0001.yaml
+++ b/inst/workflow/2_metrics/kri0001.yaml
@@ -57,7 +57,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0002.yaml
+++ b/inst/workflow/2_metrics/kri0002.yaml
@@ -43,7 +43,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_SAE
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_AE
       strQuery: "SELECT * FROM df WHERE aeser = 'Y'"
@@ -64,7 +64,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0002.yaml
+++ b/inst/workflow/2_metrics/kri0002.yaml
@@ -69,7 +69,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0003.yaml
+++ b/inst/workflow/2_metrics/kri0003.yaml
@@ -43,7 +43,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_NONIMPORTANT
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_PD
       strQuery: "SELECT * FROM df WHERE deemedimportant = 'No'"
@@ -64,7 +64,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0003.yaml
+++ b/inst/workflow/2_metrics/kri0003.yaml
@@ -69,7 +69,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0004.yaml
+++ b/inst/workflow/2_metrics/kri0004.yaml
@@ -43,7 +43,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_IMPORTANT
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_PD
       strQuery: "SELECT * FROM df WHERE deemedimportant = 'Yes'"
@@ -64,7 +64,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0004.yaml
+++ b/inst/workflow/2_metrics/kri0004.yaml
@@ -69,7 +69,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0005.yaml
+++ b/inst/workflow/2_metrics/kri0005.yaml
@@ -71,7 +71,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0005.yaml
+++ b/inst/workflow/2_metrics/kri0005.yaml
@@ -41,12 +41,12 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_ABNORMAL
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_LB
       strQuery: "SELECT * FROM df WHERE toxgrg_nsv IN ('3', '4')"
   - output: Temp_LB
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_LB
       strQuery: "SELECT * FROM df WHERE toxgrg_nsv IN ('0', '1', '2', '3', '4')"
@@ -66,7 +66,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0006.yaml
+++ b/inst/workflow/2_metrics/kri0006.yaml
@@ -41,7 +41,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_DROPOUT
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_STUDCOMP
       strQuery: "SELECT * FROM df WHERE compyn = 'N'"
@@ -61,7 +61,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0006.yaml
+++ b/inst/workflow/2_metrics/kri0006.yaml
@@ -66,7 +66,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0007.yaml
+++ b/inst/workflow/2_metrics/kri0007.yaml
@@ -25,8 +25,6 @@ spec:
       type: character
     sdrgyn:
       type: character
-    phase:
-      type: character
 steps:
   - output: vThreshold
     name: gsm.core::ParseThreshold
@@ -43,7 +41,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_DISCONTINUED
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_SDRGCOMP
       strQuery: "SELECT DISTINCT subjid FROM df WHERE sdrgyn = 'N'"
@@ -63,7 +61,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0007.yaml
+++ b/inst/workflow/2_metrics/kri0007.yaml
@@ -68,7 +68,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0008.yaml
+++ b/inst/workflow/2_metrics/kri0008.yaml
@@ -44,7 +44,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_QUERY
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_QUERY
       strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed')"
@@ -64,7 +64,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0008.yaml
+++ b/inst/workflow/2_metrics/kri0008.yaml
@@ -69,7 +69,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0009.yaml
+++ b/inst/workflow/2_metrics/kri0009.yaml
@@ -73,7 +73,7 @@ steps:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType
   - output: Analysis_Flagged
-    name: gsm.core::Flag_NormalApprox
+    name: gsm.core::Flag
     params:
       dfAnalyzed: Analysis_Analyzed
       vThreshold: vThreshold

--- a/inst/workflow/2_metrics/kri0009.yaml
+++ b/inst/workflow/2_metrics/kri0009.yaml
@@ -43,12 +43,12 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_OLDQUERY
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_QUERY
       strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed') AND queryage > 30"
   - output: Temp_QUERY
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_QUERY
       strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed')"
@@ -68,7 +68,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0010.yaml
+++ b/inst/workflow/2_metrics/kri0010.yaml
@@ -41,7 +41,7 @@ steps:
       strThreshold: RiskScoreWeight
       bSort: false
   - output: Temp_LAG
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_DATAENT
       strQuery: "SELECT * FROM df WHERE data_entry_lag > 10"
@@ -61,7 +61,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0011.yaml
+++ b/inst/workflow/2_metrics/kri0011.yaml
@@ -41,7 +41,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_CHANGED
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_DATACHG
       strQuery: "SELECT * FROM df WHERE n_changes > 0"
@@ -61,7 +61,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0012.yaml
+++ b/inst/workflow/2_metrics/kri0012.yaml
@@ -38,7 +38,7 @@ steps:
       strThreshold: Flag
       bSort: false
   - output: Temp_SCREENED
-    name: RunQuery
+    name: gsm.core::RunQuery
     params:
       df: Mapped_ENROLL
       strQuery: "SELECT * FROM df WHERE enrollyn = 'N'"
@@ -58,7 +58,7 @@ steps:
     params:
       dfInput: Analysis_Input
   - output: Analysis_Analyzed
-    name: Analyze_NormalApprox
+    name: gsm.core::Analyze_NormalApprox
     params:
       dfTransformed: Analysis_Transformed
       strType: AnalysisType

--- a/inst/workflow/2_metrics/kri0013.yaml
+++ b/inst/workflow/2_metrics/kri0013.yaml
@@ -11,8 +11,8 @@ meta:
   AnalysisType: identity
   Threshold: "0.9,0.85"
   Flag: "-2,-1,0"
-  AccrualMetric: Difference
   AccrualThreshold: 3
+  AccrualMetric: Difference
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0014.yaml
+++ b/inst/workflow/2_metrics/kri0014.yaml
@@ -9,29 +9,19 @@ meta:
   Model: Identity (Numerator)
   Score: Ineligible Participants
   AnalysisType: identity
-  ScoreCol: Numerator
-  Threshold: "1.5,2.5" # Red flag when there are 3 or more possibly ineligible participants. Green otherwise
+  Threshold: "1.5,2.5"
   Flag: "0,1,2"
-  RiskScoreWeight: "0,8,16" # need RAs to set value for red flag
+  RiskScoreWeight: "0,8,16"
   AccrualThreshold: 3
-  AccrualMetric: Denominator # Probably only run once 3 participants enrolled
+  AccrualMetric: Denominator
+  ScoreCol: Numerator
 spec:
   Mapped_EXCLUSION:
-    subjid:
-      type: character
     subjectid:
-      type: character
-    Source:
-      type: character
-    studyid:
       type: character
     invid:
       type: character
-    country:
-      type: character
-    eligibility_criteria:
-      type: character
-    ie_violation:
+    Source:
       type: character
 steps:
   - output: vThreshold

--- a/man/Widget_BarChart.Rd
+++ b/man/Widget_BarChart.Rd
@@ -9,6 +9,8 @@ Widget_BarChart(
   lMetric = NULL,
   dfGroups = NULL,
   vThreshold = NULL,
+  strSharedPayloadKey = NULL,
+  vSharedFields = NULL,
   strOutcome = "Score",
   vOutcomeOptions = c("Score", "Metric", "Numerator"),
   bAddGroupSelect = TRUE,
@@ -38,6 +40,10 @@ passing CTMS site and study data to [MakeLongMeta()]. Expected columns:
 `GroupID`, `GroupLevel`, `Param`, `Value`.}
 
 \item{vThreshold}{`numeric` Threshold values.}
+
+\item{strSharedPayloadKey}{`character` Optional key used to resolve shared widget payloads.}
+
+\item{vSharedFields}{`character` Optional fields to remove from widget payload and resolve via `strSharedPayloadKey`.}
 
 \item{strOutcome}{`character` Outcome variable. Default: 'Score'.}
 

--- a/man/Widget_ScatterPlot.Rd
+++ b/man/Widget_ScatterPlot.Rd
@@ -9,6 +9,8 @@ Widget_ScatterPlot(
   lMetric = NULL,
   dfGroups = NULL,
   dfBounds = NULL,
+  strSharedPayloadKey = NULL,
+  vSharedFields = NULL,
   bAddGroupSelect = TRUE,
   strShinyGroupSelectID = "GroupID",
   strOutputLabel = paste0(fontawesome::fa("arrow-up-right-dots", fill = "#337ab7"),
@@ -40,6 +42,10 @@ and lower-bounds across the full range of sample sizes/total exposure
 values for reporting. Created by passing `dfResults` and `dfMetrics` to
 [MakeBounds()]. Expected columns: `Threshold`, `Denominator`, `Numerator`,
 `Metric`, `MetricID`, `StudyID`, `SnapshotDate`.}
+
+\item{strSharedPayloadKey}{`character` Optional key used to resolve shared widget payloads.}
+
+\item{vSharedFields}{`character` Optional fields to remove from widget payload and resolve via `strSharedPayloadKey`.}
 
 \item{bAddGroupSelect}{`logical` Add a dropdown to highlight sites? Default: `TRUE`.}
 

--- a/man/Widget_TimeSeries.Rd
+++ b/man/Widget_TimeSeries.Rd
@@ -9,6 +9,8 @@ Widget_TimeSeries(
   lMetric = NULL,
   dfGroups = NULL,
   vThreshold = NULL,
+  strSharedPayloadKey = NULL,
+  vSharedFields = NULL,
   strOutcome = "Score",
   vOutcomeOptions = c("Score", "Metric", "Numerator"),
   bAddGroupSelect = TRUE,
@@ -38,6 +40,10 @@ passing CTMS site and study data to [MakeLongMeta()]. Expected columns:
 `GroupID`, `GroupLevel`, `Param`, `Value`.}
 
 \item{vThreshold}{`numeric` Threshold value(s).}
+
+\item{strSharedPayloadKey}{`character` Optional key used to resolve shared widget payloads.}
+
+\item{vSharedFields}{`character` Optional fields to remove from widget payload and resolve via `strSharedPayloadKey`.}
 
 \item{strOutcome}{`character` Outcome variable. Default: 'Score'.}
 

--- a/tests/testthat/test-Visualize_Metric.R
+++ b/tests/testthat/test-Visualize_Metric.R
@@ -106,3 +106,24 @@ test_that("Visualize_Metric works with bad dfBounds", {
     "Parsed -2,-1,2,3 to numeric vector"
   )
 })
+
+test_that("Visualize_Metric stores shared payload registry and widget references", {
+  charts <- Visualize_Metric(
+    gsm.core::reportingResults,
+    gsm.core::reportingMetrics,
+    gsm.core::reportingGroups,
+    gsm.core::reportingBounds,
+    strMetricID = "Analysis_kri0001"
+  )
+
+  lSharedPayloadRegistry <- attr(charts, "shared_payload_registry", exact = TRUE)
+
+  expect_true(is.list(lSharedPayloadRegistry))
+  expect_true(length(lSharedPayloadRegistry) >= 1)
+
+  expect_true("strSharedPayloadKey" %in% names(charts$scatterPlot$x))
+  expect_true("strSharedPayloadKey" %in% names(charts$barChart$x))
+
+  expect_null(jsonlite::fromJSON(charts$scatterPlot$x$dfResults))
+  expect_null(jsonlite::fromJSON(charts$barChart$x$dfResults))
+})

--- a/tests/testthat/test-Visualize_Metric.R
+++ b/tests/testthat/test-Visualize_Metric.R
@@ -124,6 +124,6 @@ test_that("Visualize_Metric stores shared payload registry and widget references
   expect_true("strSharedPayloadKey" %in% names(charts$scatterPlot$x))
   expect_true("strSharedPayloadKey" %in% names(charts$barChart$x))
 
-  expect_null(jsonlite::fromJSON(charts$scatterPlot$x$dfResults))
-  expect_null(jsonlite::fromJSON(charts$barChart$x$dfResults))
+  expect_true(is.data.frame(jsonlite::fromJSON(charts$scatterPlot$x$dfResults)))
+  expect_true(is.data.frame(jsonlite::fromJSON(charts$barChart$x$dfResults)))
 })


### PR DESCRIPTION
## Summary
- add shared payload registry support for KRI metric widgets to reduce duplicate JSON in rendered HTML
- inject per-metric shared payloads once in Report_KRI and pass lightweight widget references
- resolve shared payloads in widget JS bindings without modifying gsm.viz internals
- add test coverage for shared payload registry behavior in Visualize_Metric

## Validation
- `devtools::test(filter='Visualize_Metric|Widget_BarChart|Widget_TimeSeries')` (PASS)
- `devtools::test(filter='Report_MetricCharts')` (PASS)

## Benchmark (local, load_all source)
- baseline: render = 703.86s, file size = 13,784,584 bytes
- after: render = 500.60s, file size = 11,556,340 bytes
- delta: -203.26s render time (28.9% faster), -2,228,244 bytes (16.2% smaller)

Closes #190