### PR TITLE
Fix 226: Ignore inactive workflows

### DIFF
--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,6 @@
-# Workflow derived from
-# https://github.com/Gilead-BioStats/qcthat/tree/v1.1.1/inst/workflows/qcthat.yaml.
+# name: qcthat.yaml
+# version: 0.1.0
+# Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize, milestoned]
@@ -9,20 +10,18 @@ on:
     types: [closed]
   workflow_dispatch:
     inputs:
-      pr:
+      pr-number:
         description: PR number to which reports should be added (leave blank for none).
-        required: false
       milestone:
-        description: Milestone name to use for the milestone report (leave blank for none).
-        required: false
+        description: Milestone name to use to target the milestone report (leave blank for none).
       tag:
         description: Release tag to which the report should be attached (leave blank for none).
-        required: false
-      issueNumber:
+      qcthat-ref:
+        description: A specific qcthat GitHub reference, such as a tag ("@v1.0.0"), branch ("@dev"), commit ("@480c247"), or pull request number ("#312") to use for reports and UAT management. Defaults to the latest release, "@*release".
+      issue-number:
         description: The closed issue number to process to update user acceptance testing information.
-        required: false
 
-name: qcthat Quality Control
+name: qcthat
 
 permissions:
   # read: Required for generating reports and updating UAT status.
@@ -36,123 +35,28 @@ permissions:
   # write: Required for updating UAT status.
   actions: write
 
-# Configuration variables for controlling workflow behavior
-env:
-  qcthat_UAT: true
-  qcthat_PR_REPORT: true
-  qcthat_COMPLETED_REPORT: true
-  qcthat_MILESTONE_REPORT: true
-  qcthat_RELEASE_REPORT: true
-  qcthat_FAIL_FOR_TEST_FAILURES: true
-
 jobs:
   qcthat:
-    runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
       github.event_name != 'issues'
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: Gilead-BioStats/qcthat@main
-
-      - name: Manage User Acceptance Testing
-        if: >-
-          env.qcthat_UAT == 'true' && (
-            (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber != '')
-          )
-        run: |
-          Rscript -e "qcthat::TriggerUAT()"
-
-      - name: Generate Issue-Test Matrix
-        if: >-
-          (env.qcthat_PR_REPORT == 'true' || env.qcthat_RELEASE_REPORT == 'true' || env.qcthat_FAIL_FOR_TEST_FAILURES == 'true') && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          # Generate the full matrix for the package
-          IssueTestMatrix <- qcthat::QCPackage()
-          print(IssueTestMatrix)
-
-          # Save the matrix and UAT data for subsequent steps
-          saveRDS(IssueTestMatrix, "ITM.rds")
-          qcthat::SaveUATIssues()
-        shell: Rscript {0}
-
-      - name: Update PR Reports
-        if: >-
-          env.qcthat_PR_REPORT == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::CommentAllReports(
-            dfITM = issueTestMatrix,
-            lglPR = as.logical("${{ env.qcthat_PR_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}"),
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglUAT = as.logical("${{ env.qcthat_UAT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Update Release Reports
-        if: >-
-          env.qcthat_RELEASE_REPORT == 'true' && (
-            github.event_name == 'release' || inputs.tag != ''
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::AttachReleaseReports(
-            dfITM = issueTestMatrix,
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Flag failure for PR
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfPR <- qcthat::QCPR(dfITM = issueTestMatrix)
-          if (any(dfPR$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for PR-associated issues."
-            )
-          }
-        shell: Rscript {0}
-
-      - name: Flag failure for completed
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfCompleted = qcthat::QCCompletedIssues(dfITM = issueTestMatrix)
-          if (any(dfCompleted$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for completed issues."
-            )
-          }
-        shell: Rscript {0}
+    uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      # Configuration variables for controlling workflow behavior
+      manage-uat: true
+      generate-pr-report: true
+      generate-completed-report: true
+      generate-milestone-report: true
+      generate-release-report: true
+      fail-for-test-failures: true
+      fail-for-missing-tests: true
+      uat-assignees: ${{ (github.event_name == 'pull_request' && github.base_ref == 'main' && 'jwildfire') || (github.event_name == 'pull_request' && github.base_ref != 'main' && 'lauramaxwell,nandriychuk') || '' }}
+      # Event context passed through to the core workflow
+      has-uat-label: ${{ contains(github.event.issue.labels.*.name, 'qcthat-uat') }}
+      pr-number: ${{ github.event.pull_request.number || inputs.pr-number || '' }}
+      milestone: ${{ github.event.pull_request.milestone.title || inputs.milestone || '' }}
+      tag: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      issue-number: ${{ github.event.issue.number || inputs.issue-number || '' }}
+      qcthat-ref: ${{ inputs.qcthat-ref || '@*release' }}

--- a/R/MakeWeights.R
+++ b/R/MakeWeights.R
@@ -6,7 +6,8 @@
 #'
 #' @param dfMetrics `data.frame` Metrics metadata containing at least `MetricID`, `Flag`,
 #'   and `RiskScoreWeight` columns. The `Flag` and `RiskScoreWeight` columns should contain
-#'   comma-separated values that will be parsed into individual rows.
+#'   comma-separated values that will be parsed into individual rows. If an `Active` column
+#'   is present, rows where `Active == FALSE` are excluded before processing.
 #'
 #' @return `data.frame` Weight table with one row per MetricID-Flag combination, containing:
 #'   \describe{
@@ -47,6 +48,12 @@ MakeWeights <- function(dfMetrics) {
     )
   }
 
+  # Exclude inactive metrics if the Active column is present
+  if ("Active" %in% colnames(dfMetrics)) {
+    dfMetrics <- dfMetrics %>%
+      dplyr::filter(is.na(.data$Active) | .data$Active != FALSE)
+  }
+
   # Create weight table from dfMetrics
   weight_table <- dfMetrics %>%
     dplyr::filter(!is.na(.data$Flag) & !is.na(.data$RiskScoreWeight)) %>%
@@ -84,7 +91,7 @@ MakeWeights <- function(dfMetrics) {
   if (any(length_check$length_mismatch)) {
     mismatched_metrics <- length_check %>%
       dplyr::filter(.data$length_mismatch) %>%
-      dplyr::select(MetricID, n_flags, n_weights)
+      dplyr::select("MetricID", "n_flags", "n_weights")
 
     error_details <- paste(
       apply(mismatched_metrics, 1, function(row) {

--- a/R/Widget_GroupOverview.R
+++ b/R/Widget_GroupOverview.R
@@ -110,7 +110,7 @@ Widget_GroupOverview <- function(
         WeightMax = map_dbl(.data$Weight, ~ max(.x, na.rm = TRUE))
       ) %>%
       select("MetricID", "Flag", "Weight", "WeightMax") %>%
-      unnest(cols = c(Flag, Weight))
+      unnest(cols = c("Flag", "Weight"))
 
     dfResults <- dfResults %>%
       left_join(dfWeights, by = c("Flag", "MetricID"))

--- a/inst/workflow/2_metrics/cou0001.yaml
+++ b/inst/workflow/2_metrics/cou0001.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0001
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0001.yaml
+++ b/inst/workflow/2_metrics/cou0001.yaml
@@ -13,6 +13,7 @@ meta:
   Threshold: -2,-1,2,3
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_AE:
     subjid:

--- a/inst/workflow/2_metrics/cou0002.yaml
+++ b/inst/workflow/2_metrics/cou0002.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0002
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0002.yaml
+++ b/inst/workflow/2_metrics/cou0002.yaml
@@ -13,6 +13,7 @@ meta:
   Threshold: -2,-1,2,3
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_AE:
     subjid:

--- a/inst/workflow/2_metrics/cou0003.yaml
+++ b/inst/workflow/2_metrics/cou0003.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0003
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0003.yaml
+++ b/inst/workflow/2_metrics/cou0003.yaml
@@ -13,6 +13,7 @@ meta:
   Threshold: -3,-2,2,3
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_PD:
     subjid:

--- a/inst/workflow/2_metrics/cou0004.yaml
+++ b/inst/workflow/2_metrics/cou0004.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0004
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0004.yaml
+++ b/inst/workflow/2_metrics/cou0004.yaml
@@ -13,6 +13,7 @@ meta:
   Threshold: -3,-2,2,3
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_PD:
     subjid:

--- a/inst/workflow/2_metrics/cou0005.yaml
+++ b/inst/workflow/2_metrics/cou0005.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0005
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0005.yaml
+++ b/inst/workflow/2_metrics/cou0005.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 10
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0006.yaml
+++ b/inst/workflow/2_metrics/cou0006.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 3
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0006.yaml
+++ b/inst/workflow/2_metrics/cou0006.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0006
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0007.yaml
+++ b/inst/workflow/2_metrics/cou0007.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0007
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0007.yaml
+++ b/inst/workflow/2_metrics/cou0007.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 3
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0008.yaml
+++ b/inst/workflow/2_metrics/cou0008.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0008
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0008.yaml
+++ b/inst/workflow/2_metrics/cou0008.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_QUERY:
     subjid:

--- a/inst/workflow/2_metrics/cou0009.yaml
+++ b/inst/workflow/2_metrics/cou0009.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0009.yaml
+++ b/inst/workflow/2_metrics/cou0009.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0009
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0010.yaml
+++ b/inst/workflow/2_metrics/cou0010.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0010.yaml
+++ b/inst/workflow/2_metrics/cou0010.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0010
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0011.yaml
+++ b/inst/workflow/2_metrics/cou0011.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0011
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0011.yaml
+++ b/inst/workflow/2_metrics/cou0011.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 100
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0012.yaml
+++ b/inst/workflow/2_metrics/cou0012.yaml
@@ -13,6 +13,7 @@ meta:
   Threshold: -3,-2,2,3
   AccrualThreshold: 3
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_ENROLL:
     subjectid:

--- a/inst/workflow/2_metrics/cou0012.yaml
+++ b/inst/workflow/2_metrics/cou0012.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0012
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0013.yaml
+++ b/inst/workflow/2_metrics/cou0013.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0013
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0013.yaml
+++ b/inst/workflow/2_metrics/cou0013.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "-2,-1,0"
   AccrualMetric: Difference
   AccrualThreshold: 3
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/cou0014.yaml
+++ b/inst/workflow/2_metrics/cou0014.yaml
@@ -16,6 +16,7 @@ meta:
   RiskScoreWeight: "0,8,16"
   AccrualThreshold: 3
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_EXCLUSION:
     subjid:

--- a/inst/workflow/2_metrics/cou0014.yaml
+++ b/inst/workflow/2_metrics/cou0014.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0014
   GroupLevel: Country

--- a/inst/workflow/2_metrics/cou0015.yaml
+++ b/inst/workflow/2_metrics/cou0015.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "0,1,2"
   AccrualThreshold: 1
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_Death:
     subjid:

--- a/inst/workflow/2_metrics/cou0015.yaml
+++ b/inst/workflow/2_metrics/cou0015.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: cou0015
   GroupLevel: Country

--- a/inst/workflow/2_metrics/kri0001.yaml
+++ b/inst/workflow/2_metrics/kri0001.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0001
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0001.yaml
+++ b/inst/workflow/2_metrics/kri0001.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "32,16,0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_AE:
     subjid:

--- a/inst/workflow/2_metrics/kri0002.yaml
+++ b/inst/workflow/2_metrics/kri0002.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "8,0,0,4,8"
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_AE:
     subjid:

--- a/inst/workflow/2_metrics/kri0002.yaml
+++ b/inst/workflow/2_metrics/kri0002.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0002
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0003.yaml
+++ b/inst/workflow/2_metrics/kri0003.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0003
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0003.yaml
+++ b/inst/workflow/2_metrics/kri0003.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "8,4,0,8,16"
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_PD:
     subjid:

--- a/inst/workflow/2_metrics/kri0004.yaml
+++ b/inst/workflow/2_metrics/kri0004.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,0,0,16,32"
   AccrualThreshold: 30
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_PD:
     subjid:

--- a/inst/workflow/2_metrics/kri0004.yaml
+++ b/inst/workflow/2_metrics/kri0004.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0004
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0005.yaml
+++ b/inst/workflow/2_metrics/kri0005.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0005
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0005.yaml
+++ b/inst/workflow/2_metrics/kri0005.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,1,2"
   AccrualThreshold: 10
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0006.yaml
+++ b/inst/workflow/2_metrics/kri0006.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,16,32"
   AccrualThreshold: 3
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0006.yaml
+++ b/inst/workflow/2_metrics/kri0006.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0006
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0007.yaml
+++ b/inst/workflow/2_metrics/kri0007.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,16,32"
   AccrualThreshold: 3
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0007.yaml
+++ b/inst/workflow/2_metrics/kri0007.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0007
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0008.yaml
+++ b/inst/workflow/2_metrics/kri0008.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_QUERY:
     subjid:

--- a/inst/workflow/2_metrics/kri0008.yaml
+++ b/inst/workflow/2_metrics/kri0008.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0008
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0009.yaml
+++ b/inst/workflow/2_metrics/kri0009.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0009.yaml
+++ b/inst/workflow/2_metrics/kri0009.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0009
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0010.yaml
+++ b/inst/workflow/2_metrics/kri0010.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0010
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0010.yaml
+++ b/inst/workflow/2_metrics/kri0010.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,1,2"
   AccrualThreshold: 30
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0011.yaml
+++ b/inst/workflow/2_metrics/kri0011.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0011
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0011.yaml
+++ b/inst/workflow/2_metrics/kri0011.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,1,2"
   AccrualThreshold: 100
   AccrualMetric: Numerator
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0012.yaml
+++ b/inst/workflow/2_metrics/kri0012.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,0,0,8,16"
   AccrualThreshold: 3
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_ENROLL:
     subjectid:

--- a/inst/workflow/2_metrics/kri0012.yaml
+++ b/inst/workflow/2_metrics/kri0012.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0012
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0013.yaml
+++ b/inst/workflow/2_metrics/kri0013.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0013
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0013.yaml
+++ b/inst/workflow/2_metrics/kri0013.yaml
@@ -14,6 +14,7 @@ meta:
   Flag: "-2,-1,0"
   AccrualMetric: Difference
   AccrualThreshold: 3
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/kri0014.yaml
+++ b/inst/workflow/2_metrics/kri0014.yaml
@@ -16,6 +16,7 @@ meta:
   RiskScoreWeight: "0,8,16" # need RAs to set value for red flag
   AccrualThreshold: 3
   AccrualMetric: Denominator # Probably only run once 3 participants enrolled
+  GenerateRiskSignal: true
 spec:
   Mapped_EXCLUSION:
     subjid:

--- a/inst/workflow/2_metrics/kri0014.yaml
+++ b/inst/workflow/2_metrics/kri0014.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0014
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0015.yaml
+++ b/inst/workflow/2_metrics/kri0015.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: kri0015
   GroupLevel: Site

--- a/inst/workflow/2_metrics/kri0015.yaml
+++ b/inst/workflow/2_metrics/kri0015.yaml
@@ -15,6 +15,7 @@ meta:
   RiskScoreWeight: "0,8,16"
   AccrualThreshold: 1
   AccrualMetric: Denominator
+  GenerateRiskSignal: true
 spec:
   Mapped_Death:
     subjid:

--- a/inst/workflow/2_metrics/srs0001.yaml
+++ b/inst/workflow/2_metrics/srs0001.yaml
@@ -1,4 +1,5 @@
 meta:
+  Active: true
   Type: Analysis
   ID: srs0001
   GroupLevel: Site

--- a/inst/workflow/2_metrics/srs0001.yaml
+++ b/inst/workflow/2_metrics/srs0001.yaml
@@ -11,6 +11,7 @@ meta:
   Score: Normalized Risk Score
   AnalysisType: identity
   Priority: 4
+  GenerateRiskSignal: true
 steps:
   - output: lAnalysis_filtered
     name: gsm.kri::FilterAnalysis

--- a/inst/workflow/4_modules/report_eligibility.yaml
+++ b/inst/workflow/4_modules/report_eligibility.yaml
@@ -4,6 +4,7 @@ meta:
   Output: html
   Name: CTQ Eligibility Report
   Description: A report summarizing CTQ
+  Active: true
 spec:
   Mapped_EXCLUSION:
     _all:

--- a/inst/workflow/4_modules/report_kri_country.yaml
+++ b/inst/workflow/4_modules/report_kri_country.yaml
@@ -4,6 +4,7 @@ meta:
   Output: html
   Name: Country-Level Key Risk Indicator Report
   Description: A report summarizing key risk indicators at the country level.
+  Active: true
 spec:
   Reporting_Results:
     _all:

--- a/inst/workflow/4_modules/report_kri_site.yaml
+++ b/inst/workflow/4_modules/report_kri_site.yaml
@@ -4,6 +4,7 @@ meta:
   Output: html
   Name: Site-Level Key Risk Indicator Report
   Description: A report summarizing key risk indicators at the site level
+  Active: true
 spec:
   Reporting_Results:
     _all:

--- a/man/MakeWeights.Rd
+++ b/man/MakeWeights.Rd
@@ -9,7 +9,8 @@ MakeWeights(dfMetrics)
 \arguments{
 \item{dfMetrics}{`data.frame` Metrics metadata containing at least `MetricID`, `Flag`,
 and `RiskScoreWeight` columns. The `Flag` and `RiskScoreWeight` columns should contain
-comma-separated values that will be parsed into individual rows.}
+comma-separated values that will be parsed into individual rows. If an `Active` column
+is present, rows where `Active == FALSE` are excluded before processing.}
 }
 \value{
 `data.frame` Weight table with one row per MetricID-Flag combination, containing:

--- a/tests/testthat/test-CalculateRiskScore.R
+++ b/tests/testthat/test-CalculateRiskScore.R
@@ -419,3 +419,42 @@ test_that("CalculateRiskScore handles multiple group levels (#127)", {
   expect_true("Site002" %in% dfRiskScore$GroupID)
   expect_true("Canada" %in% dfRiskScore$GroupID)
 })
+
+# Active metric filtering tests ----
+
+test_that("CalculateRiskScore excludes inactive metrics from denominator (#226)", {
+  # Only active metrics appear in dfResults (inactive ones are never run)
+  dfResults <- data.frame(
+    GroupLevel = rep("Site", 4),
+    GroupID = rep(c("Site001", "Site002"), each = 2),
+    MetricID = rep(c("Analysis_kri0001", "Analysis_kri0002"), 2),
+    Flag = c(1, 2, 0, -1),
+    stringsAsFactors = FALSE
+  )
+  # kri0003 is inactive; its WeightMax (16) should NOT inflate the denominator
+  dfMetrics_with_inactive <- data.frame(
+    MetricID = c("Analysis_kri0001", "Analysis_kri0002", "Analysis_kri0003"),
+    Flag = rep("-2,-1,0,1,2", 3),
+    RiskScoreWeight = c("4,2,0,2,4", "8,4,0,4,8", "16,8,0,8,16"),
+    Active = c(TRUE, TRUE, FALSE),
+    stringsAsFactors = FALSE
+  )
+  dfMetrics_active_only <- data.frame(
+    MetricID = c("Analysis_kri0001", "Analysis_kri0002"),
+    Flag = rep("-2,-1,0,1,2", 2),
+    RiskScoreWeight = c("4,2,0,2,4", "8,4,0,4,8"),
+    stringsAsFactors = FALSE
+  )
+
+  dfWeights_with_inactive <- MakeWeights(dfMetrics_with_inactive)
+  dfWeights_active_only <- MakeWeights(dfMetrics_active_only)
+
+  # Both should produce the same results because kri0003 is filtered out
+  dfRiskScore_inactive <- CalculateRiskScore(dfResults, dfWeights_with_inactive)
+  dfRiskScore_active <- CalculateRiskScore(dfResults, dfWeights_active_only)
+
+  # Denominator = 4 + 8 = 12 (active metrics only)
+  expect_equal(unique(dfRiskScore_inactive$Denominator), 12)
+  expect_equal(dfRiskScore_inactive$Denominator, dfRiskScore_active$Denominator)
+  expect_equal(dfRiskScore_inactive$Numerator, dfRiskScore_active$Numerator)
+})

--- a/tests/testthat/test-MakeWeights.R
+++ b/tests/testthat/test-MakeWeights.R
@@ -412,3 +412,50 @@ test_that("MakeWeights succeeds when all lengths match (#135)", {
   # Should not throw an error
   expect_silent(dfWeights <- MakeWeights(dfMetrics_match))
 })
+
+# Active column filtering tests ----
+
+test_that("MakeWeights excludes inactive metrics from weight table (#226)", {
+  dfMetrics <- data.frame(
+    MetricID = c("Analysis_kri0001", "Analysis_kri0002", "Analysis_kri0003"),
+    Flag = c("-2,-1,0,1,2", "-2,-1,0,1,2", "-2,-1,0,1,2"),
+    RiskScoreWeight = c("4,2,0,2,4", "4,2,0,2,4", "4,2,0,2,4"),
+    Active = c(TRUE, FALSE, TRUE),
+    stringsAsFactors = FALSE
+  )
+
+  dfWeights <- MakeWeights(dfMetrics)
+
+  expect_false("Analysis_kri0002" %in% dfWeights$MetricID)
+  expect_true("Analysis_kri0001" %in% dfWeights$MetricID)
+  expect_true("Analysis_kri0003" %in% dfWeights$MetricID)
+})
+
+test_that("MakeWeights includes all metrics when Active column is absent (#226)", {
+  dfMetrics <- data.frame(
+    MetricID = c("Analysis_kri0001", "Analysis_kri0002"),
+    Flag = c("-2,-1,0,1,2", "-2,-1,0,1,2"),
+    RiskScoreWeight = c("4,2,0,2,4", "4,2,0,2,4"),
+    stringsAsFactors = FALSE
+  )
+
+  dfWeights <- MakeWeights(dfMetrics)
+
+  expect_true("Analysis_kri0001" %in% dfWeights$MetricID)
+  expect_true("Analysis_kri0002" %in% dfWeights$MetricID)
+})
+
+test_that("MakeWeights includes metrics with NA Active (#226)", {
+  dfMetrics <- data.frame(
+    MetricID = c("Analysis_kri0001", "Analysis_kri0002"),
+    Flag = c("-2,-1,0,1,2", "-2,-1,0,1,2"),
+    RiskScoreWeight = c("4,2,0,2,4", "4,2,0,2,4"),
+    Active = c(TRUE, NA),
+    stringsAsFactors = FALSE
+  )
+
+  dfWeights <- MakeWeights(dfMetrics)
+
+  expect_true("Analysis_kri0001" %in% dfWeights$MetricID)
+  expect_true("Analysis_kri0002" %in% dfWeights$MetricID)
+})


### PR DESCRIPTION
Add `Active: true` to workflows, and don't count inactive workflows (workflows with explicit `Active: false`) in `CalculateRiskScore()`. Also add `GenerateRiskSignal: true` to metric workflows.

Also updated `qcthat.yaml` GHA workflow, and eliminated R CMD check Note.

Claude Sonnet 4.6 prompts:

```
Implement #226
```

After feature was implemented, but Note was noticed (and ignored, since it was already there):

```
Fix the "no visible binding" note using the `data` pronoun from the tidyverse (already available, so you can use `data$MetricID`, etc), or by "quoting" the column name if it's used in something with "tidy-select" semantics (such as `dplyr::select()`).
```

- Closes #226.