### PR TITLE
Ensure css is implemented on pkgdown reports

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,162 @@
+/* Report styles for pkgdown site */
+/* These styles are needed because pkgdown ignores the css: parameter */
+/* in article YAML headers, so styles.css from the examples directory */
+/* is not loaded on the published site. */
+
+/* MAIN */
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;400');
+
+:root {
+  --good-red: #c51f3f;
+  --good-gray: #9D9D9D;
+  --blue-button-color: #3C587F;
+  --default: 'Roboto', sans-serif;
+}
+
+/* TABLE: FLAGGED SUMMARY TABLE */
+.Widget_GroupOverview {
+    height: auto !important;
+}
+.gsm-overview-table {
+  font-family: var(--default);
+}
+table.dataTable thead>tr>th.sorting, table.dataTable thead>tr>th.sorting_asc, table.dataTable thead>tr>th.sorting_desc, table.dataTable thead>tr>th.sorting_asc_disabled, table.dataTable thead>tr>th.sorting_desc_disabled, table.dataTable thead>tr>td.sorting, table.dataTable thead>tr>td.sorting_asc, table.dataTable thead>tr>td.sorting_desc, table.dataTable thead>tr>td.sorting_asc_disabled, table.dataTable thead>tr>td.sorting_desc_disabled {
+    padding-right: 16px;
+}
+table.dataTable.compact thead th, table.dataTable.compact thead td {
+    padding: 4px 4px;
+}
+/* TABLE: FLAGGED SUMMARY TABLE */
+
+/* Group select */
+.overall-group-select {
+  position: fixed;
+  width: 128px;
+  top: 64px;
+  right: 32px;
+  background-color: var(--blue-button-color);
+  color: white;
+  border: 2px solid var(--good-gray);
+  border-radius: 4px;
+  padding: 4px;
+  text-align: center;
+  z-index: 1;
+}
+
+.overall-group-select:hover {
+  cursor: grab;
+}
+
+/* font color for drop-down */
+.gsm-overview-table .dataTables_wrapper .dataTables_length select {
+  color: var(--good-red);
+}
+
+.overall-group-select select,
+.overall-group-select option {
+    color: black;
+}
+
+.flag {
+  display: inline-block;
+  border-style: solid;
+  border-color: black;
+  font-weight: bold;
+  text-align: center;
+  margin: 5px;
+  width: 20%;
+  font-family: 'Roboto', sans-serif;
+}
+
+.flag-amber {
+  background-color: #FEAA0280;
+}
+
+.flag-red {
+  background-color: #FF585980;
+}
+
+.flag-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#tocify-header0 {
+  display: none;
+}
+
+/* Group summary table -- change cursor to cue to user that tooltip is available */
+td[title] {
+  cursor: help;
+}
+
+tbody.gt_table_body tr:hover:nth-child(odd) {
+  background: #f9f9f9;
+}
+
+#timeline {
+  display: none;
+}
+
+/* Flag Change List Styles */
+.flag-change-list {
+  list-style-type: disc;
+  margin-left: 1.5em;
+}
+.flag-change-parent {
+  margin-bottom: 1em;
+  font-weight: bold;
+  list-style-type: none;
+  position: relative;
+}
+.flag-change-parent::before {
+  content: "+ ";
+  position: absolute;
+  left: -1.2em;
+  font-weight: bold;
+  color: #888;
+}
+.flag-change-parent.expanded::before {
+  content: "\2212 "; /* Unicode minus sign */
+  color: #888;
+}
+.flag-change-nested {
+  list-style-type: circle;
+  margin-left: 2em;
+  display: none;
+}
+.flag-change-parent:not(.expandable)::before {
+  content: none;
+}
+.flag-change-item {
+  margin-bottom: 0.5em;
+  font-weight: normal;
+  list-style-type: none;
+  position: relative;
+}
+.flag-change-item::before {
+  content: "+ ";
+  position: absolute;
+  left: -1.2em;
+  font-weight: bold;
+  color: #888;
+}
+.flag-change-item.expanded::before {
+  content: "\2212 "; /* Unicode minus sign */
+  color: #888;
+}
+.flag-change-details {
+  list-style-type: square;
+  margin-left: 2em;
+  color: #444;
+  font-size: 0.95em;
+  display: none;
+}
+.flag-change-item:not(.expandable)::before {
+  content: none;
+}
+.flag-change-parent:hover, .flag-change-item:hover {
+  background: #f5f5f5;
+  cursor: pointer;
+}

--- a/tests/testthat/test-pkgdown-css.R
+++ b/tests/testthat/test-pkgdown-css.R
@@ -1,0 +1,60 @@
+# pkgdown ignores the css: YAML parameter in menu articles, so report styles
+# must be duplicated in pkgdown/extra.css (#240).
+
+test_that("pkgdown/extra.css exists", {
+  extra_css <- system.file("../pkgdown/extra.css", package = "gsm.kri")
+  # system.file returns "" when the path is outside inst/; use file path instead
+  extra_css_path <- file.path(
+    system.file(package = "gsm.kri"),
+    "..", "pkgdown", "extra.css"
+  )
+
+  skip_if_not(file.exists(extra_css_path), "pkgdown/extra.css not found (likely in installed package)")
+
+  extra_css_content <- readLines(extra_css_path)
+  extra_css_text <- paste(extra_css_content, collapse = "\n")
+
+  expect_match(
+    extra_css_text,
+    "Widget_GroupOverview",
+    fixed = TRUE,
+    label = "extra.css must style Widget_GroupOverview"
+  )
+
+  expect_match(
+    extra_css_text,
+    "height:\\s*auto\\s*!important",
+    label = "extra.css must override widget height to auto"
+  )
+})
+
+test_that("pkgdown/extra.css contains all critical rules from inst/report/styles.css", {
+  report_css_path <- system.file("report", "styles.css", package = "gsm.kri")
+  extra_css_path <- file.path(
+    system.file(package = "gsm.kri"),
+    "..", "pkgdown", "extra.css"
+  )
+
+  skip_if_not(file.exists(extra_css_path), "pkgdown/extra.css not found (likely in installed package)")
+
+  extra_css_text <- paste(readLines(extra_css_path), collapse = "\n")
+
+  # These selectors are critical for correct report rendering on the pkgdown site.
+  critical_selectors <- c(
+    ".Widget_GroupOverview",
+    ".gsm-overview-table",
+    ".overall-group-select",
+    ".flag-container",
+    ".flag-amber",
+    ".flag-red"
+  )
+
+  for (selector in critical_selectors) {
+    expect_match(
+      extra_css_text,
+      selector,
+      fixed = TRUE,
+      label = paste("extra.css must contain selector:", selector)
+    )
+  }
+})


### PR DESCRIPTION
Addressing this issue by ensuring css is used properly in pkgdown examples/reports

<img width="1164" height="864" alt="image" src="https://github.com/user-attachments/assets/be455f8a-6d0e-450d-a125-6304fbfb7223" />
