### PR TITLE
Gsm.kri v1.5.2 rc

### DIFF
--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,6 @@
-# Workflow derived from
-# https://github.com/Gilead-BioStats/qcthat/tree/v1.1.1/inst/workflows/qcthat.yaml.
+# name: qcthat.yaml
+# version: 0.1.0
+# Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize, milestoned]
@@ -9,20 +10,18 @@ on:
     types: [closed]
   workflow_dispatch:
     inputs:
-      pr:
+      pr-number:
         description: PR number to which reports should be added (leave blank for none).
-        required: false
       milestone:
-        description: Milestone name to use for the milestone report (leave blank for none).
-        required: false
+        description: Milestone name to use to target the milestone report (leave blank for none).
       tag:
         description: Release tag to which the report should be attached (leave blank for none).
-        required: false
-      issueNumber:
+      qcthat-ref:
+        description: A specific qcthat GitHub reference, such as a tag ("@v1.0.0"), branch ("@dev"), commit ("@480c247"), or pull request number ("#312") to use for reports and UAT management. Defaults to the latest release, "@*release".
+      issue-number:
         description: The closed issue number to process to update user acceptance testing information.
-        required: false
 
-name: qcthat Quality Control
+name: qcthat
 
 permissions:
   # read: Required for generating reports and updating UAT status.
@@ -36,123 +35,28 @@ permissions:
   # write: Required for updating UAT status.
   actions: write
 
-# Configuration variables for controlling workflow behavior
-env:
-  qcthat_UAT: true
-  qcthat_PR_REPORT: true
-  qcthat_COMPLETED_REPORT: true
-  qcthat_MILESTONE_REPORT: true
-  qcthat_RELEASE_REPORT: true
-  qcthat_FAIL_FOR_TEST_FAILURES: true
-
 jobs:
   qcthat:
-    runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
       github.event_name != 'issues'
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: Gilead-BioStats/qcthat@main
-
-      - name: Manage User Acceptance Testing
-        if: >-
-          env.qcthat_UAT == 'true' && (
-            (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber != '')
-          )
-        run: |
-          Rscript -e "qcthat::TriggerUAT()"
-
-      - name: Generate Issue-Test Matrix
-        if: >-
-          (env.qcthat_PR_REPORT == 'true' || env.qcthat_RELEASE_REPORT == 'true' || env.qcthat_FAIL_FOR_TEST_FAILURES == 'true') && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          # Generate the full matrix for the package
-          IssueTestMatrix <- qcthat::QCPackage()
-          print(IssueTestMatrix)
-
-          # Save the matrix and UAT data for subsequent steps
-          saveRDS(IssueTestMatrix, "ITM.rds")
-          qcthat::SaveUATIssues()
-        shell: Rscript {0}
-
-      - name: Update PR Reports
-        if: >-
-          env.qcthat_PR_REPORT == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::CommentAllReports(
-            dfITM = issueTestMatrix,
-            lglPR = as.logical("${{ env.qcthat_PR_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}"),
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglUAT = as.logical("${{ env.qcthat_UAT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Update Release Reports
-        if: >-
-          env.qcthat_RELEASE_REPORT == 'true' && (
-            github.event_name == 'release' || inputs.tag != ''
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::AttachReleaseReports(
-            dfITM = issueTestMatrix,
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Flag failure for PR
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfPR <- qcthat::QCPR(dfITM = issueTestMatrix)
-          if (any(dfPR$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for PR-associated issues."
-            )
-          }
-        shell: Rscript {0}
-
-      - name: Flag failure for completed
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfCompleted = qcthat::QCCompletedIssues(dfITM = issueTestMatrix)
-          if (any(dfCompleted$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for completed issues."
-            )
-          }
-        shell: Rscript {0}
+    uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      # Configuration variables for controlling workflow behavior
+      manage-uat: true
+      generate-pr-report: true
+      generate-completed-report: true
+      generate-milestone-report: true
+      generate-release-report: true
+      fail-for-test-failures: true
+      fail-for-missing-tests: true
+      uat-assignees: ${{ (github.event_name == 'pull_request' && github.base_ref == 'main' && 'jwildfire') || (github.event_name == 'pull_request' && github.base_ref != 'main' && 'lauramaxwell,nandriychuk') || '' }}
+      # Event context passed through to the core workflow
+      has-uat-label: ${{ contains(github.event.issue.labels.*.name, 'qcthat-uat') }}
+      pr-number: ${{ github.event.pull_request.number || inputs.pr-number || '' }}
+      milestone: ${{ github.event.pull_request.milestone.title || inputs.milestone || '' }}
+      tag: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      issue-number: ${{ github.event.issue.number || inputs.issue-number || '' }}
+      qcthat-ref: ${{ inputs.qcthat-ref || '@*release' }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Remotes:
     gsm.mapping=Gilead-BioStats/gsm.mapping@main,
     gsm.qtl=Gilead-BioStats/gsm.qtl@main,
     gsm.reporting=Gilead-BioStats/gsm.reporting@main,
-    qcthat=Gilead-BioStats/qcthat@main
+    qcthat=Gilead-BioStats/qcthat@*release
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gsm.kri
 Title: Good Statistical Monitoring KRIs
-Version: 1.5.1
+Version: 1.5.2
 Authors@R: c(
     person("Jeremy", "Wildfire", , "jwildfire@gmail.com", role = c("aut", "cre")),
     person("Laura", "Maxwell", , "laura.maxwell@atorusresearch.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# gsm.kri v1.5.2
+
+This patch release fixes report display issues on the pkgdown site and renders missing examples.
+
+**Bug Fixes:**
+- Fix overlapping summary table and text in Site/Country Report examples on the pkgdown site (#240)
+- Render missing pkgdown examples (#228)
+
 # gsm.kri v1.5.1
 
 This patch release updates the GitHub action workflows to align with the new federated action framework in `gsm.utils`

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,20 +17,3 @@ navbar:
     github:
       icon: fab fa-github
       href: https://github.com/gilead-biostats/gsm.kri
-    examples:
-      text: Examples
-      menu:
-      - text: Cookbook AdverseEventKRI
-        href: examples/Cookbook_AdverseEventKRI.html
-      - text: Cookbook AdverseEventWorkflow
-        href: examples/Cookbook_AdverseEventWorkflow.html
-      - text: Cookbook ReportingWorkflow
-        href: examples/Cookbook_ReportingWorkflow.html
-      - text: Example CrossStudySRS
-        href: examples/Example_CrossStudySRS.html
-      - text: Report Eligibility
-        href: examples/Report_Eligibility.html
-      - text: Report Kri Country
-        href: examples/report_kri_country.html
-      - text: Report Kri Site
-        href: examples/report_kri_site.html

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,162 @@
+/* Report styles for pkgdown site */
+/* These styles are needed because pkgdown ignores the css: parameter */
+/* in article YAML headers, so styles.css from the examples directory */
+/* is not loaded on the published site. */
+
+/* MAIN */
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;400');
+
+:root {
+  --good-red: #c51f3f;
+  --good-gray: #9D9D9D;
+  --blue-button-color: #3C587F;
+  --default: 'Roboto', sans-serif;
+}
+
+/* TABLE: FLAGGED SUMMARY TABLE */
+.Widget_GroupOverview {
+    height: auto !important;
+}
+.gsm-overview-table {
+  font-family: var(--default);
+}
+table.dataTable thead>tr>th.sorting, table.dataTable thead>tr>th.sorting_asc, table.dataTable thead>tr>th.sorting_desc, table.dataTable thead>tr>th.sorting_asc_disabled, table.dataTable thead>tr>th.sorting_desc_disabled, table.dataTable thead>tr>td.sorting, table.dataTable thead>tr>td.sorting_asc, table.dataTable thead>tr>td.sorting_desc, table.dataTable thead>tr>td.sorting_asc_disabled, table.dataTable thead>tr>td.sorting_desc_disabled {
+    padding-right: 16px;
+}
+table.dataTable.compact thead th, table.dataTable.compact thead td {
+    padding: 4px 4px;
+}
+/* TABLE: FLAGGED SUMMARY TABLE */
+
+/* Group select */
+.overall-group-select {
+  position: fixed;
+  width: 128px;
+  top: 64px;
+  right: 32px;
+  background-color: var(--blue-button-color);
+  color: white;
+  border: 2px solid var(--good-gray);
+  border-radius: 4px;
+  padding: 4px;
+  text-align: center;
+  z-index: 1;
+}
+
+.overall-group-select:hover {
+  cursor: grab;
+}
+
+/* font color for drop-down */
+.gsm-overview-table .dataTables_wrapper .dataTables_length select {
+  color: var(--good-red);
+}
+
+.overall-group-select select,
+.overall-group-select option {
+    color: black;
+}
+
+.flag {
+  display: inline-block;
+  border-style: solid;
+  border-color: black;
+  font-weight: bold;
+  text-align: center;
+  margin: 5px;
+  width: 20%;
+  font-family: 'Roboto', sans-serif;
+}
+
+.flag-amber {
+  background-color: #FEAA0280;
+}
+
+.flag-red {
+  background-color: #FF585980;
+}
+
+.flag-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#tocify-header0 {
+  display: none;
+}
+
+/* Group summary table -- change cursor to cue to user that tooltip is available */
+td[title] {
+  cursor: help;
+}
+
+tbody.gt_table_body tr:hover:nth-child(odd) {
+  background: #f9f9f9;
+}
+
+#timeline {
+  display: none;
+}
+
+/* Flag Change List Styles */
+.flag-change-list {
+  list-style-type: disc;
+  margin-left: 1.5em;
+}
+.flag-change-parent {
+  margin-bottom: 1em;
+  font-weight: bold;
+  list-style-type: none;
+  position: relative;
+}
+.flag-change-parent::before {
+  content: "+ ";
+  position: absolute;
+  left: -1.2em;
+  font-weight: bold;
+  color: #888;
+}
+.flag-change-parent.expanded::before {
+  content: "\2212 "; /* Unicode minus sign */
+  color: #888;
+}
+.flag-change-nested {
+  list-style-type: circle;
+  margin-left: 2em;
+  display: none;
+}
+.flag-change-parent:not(.expandable)::before {
+  content: none;
+}
+.flag-change-item {
+  margin-bottom: 0.5em;
+  font-weight: normal;
+  list-style-type: none;
+  position: relative;
+}
+.flag-change-item::before {
+  content: "+ ";
+  position: absolute;
+  left: -1.2em;
+  font-weight: bold;
+  color: #888;
+}
+.flag-change-item.expanded::before {
+  content: "\2212 "; /* Unicode minus sign */
+  color: #888;
+}
+.flag-change-details {
+  list-style-type: square;
+  margin-left: 2em;
+  color: #444;
+  font-size: 0.95em;
+  display: none;
+}
+.flag-change-item:not(.expandable)::before {
+  content: none;
+}
+.flag-change-parent:hover, .flag-change-item:hover {
+  background: #f5f5f5;
+  cursor: pointer;
+}

--- a/pkgdown/menus/examples/Cookbook_AdverseEventKRI.Rmd
+++ b/pkgdown/menus/examples/Cookbook_AdverseEventKRI.Rmd
@@ -34,7 +34,7 @@ Load required packages and data:
 library(gsm.core)
 library(gsm.mapping)
 library(dplyr)
-devtools::load_all()
+library(gsm.kri)
 
 # Load source data
 dm <- gsm.core::lSource$Raw_SUBJ

--- a/pkgdown/menus/examples/Cookbook_AdverseEventWorkflow.Rmd
+++ b/pkgdown/menus/examples/Cookbook_AdverseEventWorkflow.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(
 library(gsm.core)
 library(gsm.mapping)
 library(yaml)
-devtools::load_all()
+library(gsm.kri)
 ```
 
 ## Example 2.1 - Configurable Adverse Event Workflow

--- a/pkgdown/menus/examples/Example_CountryReport.Rmd
+++ b/pkgdown/menus/examples/Example_CountryReport.Rmd
@@ -11,7 +11,7 @@ output:
     toc_float:
       collapsed: false
       smooth_scroll: true
-    css: ../report/styles.css
+    css: styles.css
 ---
 
 

--- a/pkgdown/menus/examples/Example_CrossStudySRS.Rmd
+++ b/pkgdown/menus/examples/Example_CrossStudySRS.Rmd
@@ -19,9 +19,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r load-packages}
-# Load development version
-devtools::load_all()
-
+library(gsm.kri)
 library(gsm.core)
 library(dplyr)
 library(htmlwidgets)

--- a/pkgdown/menus/examples/Example_Eligibility.Rmd
+++ b/pkgdown/menus/examples/Example_Eligibility.Rmd
@@ -11,7 +11,7 @@ output:
     toc_float:
       collapsed: false
       smooth_scroll: true
-    css: ../report/styles.css
+    css: styles.css
 ---
 # Set Up 
 This page provides a sample Eligibility Report generated using `gsm.kri` package. Expand the "Setup" section below to see the code used to generate the report. Or scroll down for the standard report output.

--- a/pkgdown/menus/examples/Example_SiteReport.Rmd
+++ b/pkgdown/menus/examples/Example_SiteReport.Rmd
@@ -11,7 +11,7 @@ output:
     toc_float:
       collapsed: false
       smooth_scroll: true
-    css: ../report/styles.css
+    css: styles.css
 ---
 
 # Set Up

--- a/pkgdown/menus/examples/styles.css
+++ b/pkgdown/menus/examples/styles.css
@@ -1,0 +1,199 @@
+/* MAIN */
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;400');
+
+:root {
+  --good-red: #c51f3f;
+  --good-gray: #9D9D9D;
+  --blue-button-color: #3C587F;
+  --default: 'Roboto', sans-serif;
+}
+
+body {
+  font-family: 'Roboto', sans-serif;
+}
+/* MAIN */
+
+
+/* SIDEBAR */
+.list-group-item.active, .list-group-item.active:focus, .list-group-item.active:hover {
+  background-color: var(--good-gray);
+  border-color: white;
+}
+/* SIDEBAR */
+
+
+
+/* BUTTON: SHOW REPORT */
+.btn-show-report {
+    background-color: var(--blue-button-color);
+    color: white;
+    font-family: 'Roboto', sans-serif;
+    font-weight: 400;
+    border-radius: 1.5px;
+    border-color: var(--blue-button-color);
+    box-shadow: none;
+    border-style: solid;
+    height: 30px;
+    width: 100px;
+}
+
+button.btn-show-report:hover {
+    background-color: var(--good-gray);
+    border-color: var(--good-gray);
+}
+/* BUTTON: SHOW REPORT */
+
+
+
+/* TABLE: FLAGGED SUMMARY TABLE */
+.Widget_GroupOverview {
+    height: auto !important;
+}
+.gsm-overview-table {
+  font-family: var(--default);
+}
+table.dataTable thead>tr>th.sorting, table.dataTable thead>tr>th.sorting_asc, table.dataTable thead>tr>th.sorting_desc, table.dataTable thead>tr>th.sorting_asc_disabled, table.dataTable thead>tr>th.sorting_desc_disabled, table.dataTable thead>tr>td.sorting, table.dataTable thead>tr>td.sorting_asc, table.dataTable thead>tr>td.sorting_desc, table.dataTable thead>tr>td.sorting_asc_disabled, table.dataTable thead>tr>td.sorting_desc_disabled {
+    padding-right: 16px;
+}
+table.dataTable.compact thead th, table.dataTable.compact thead td {
+    padding: 4px 4px;
+}
+/* TABLE: FLAGGED SUMMARY TABLE */
+
+/* Group select */
+.overall-group-select {
+  position: fixed;
+  width: 128px;
+  top: 64px;
+  right: 32px;
+  background-color: var(--blue-button-color);
+  color: white;
+  border: 2px solid var(--good-gray);
+  border-radius: 4px;
+  padding: 4px;
+  text-align: center;
+  z-index: 1;
+}
+
+.overall-group-select:hover {
+  cursor: grab;
+}
+
+/* font color for drop-down */
+
+.gsm-overview-table .dataTables_wrapper .dataTables_length select {
+  color: var(--good-red);
+}
+
+
+
+.overall-group-select select,
+.overall-group-select option {
+    color: black;
+}
+
+.flag {
+  display: inline-block;
+  border-style: solid;
+  border-color: black;
+  font-weight: bold;
+  text-align: center;
+  margin: 5px;
+  width: 20%;
+  font-family: 'Roboto', sans-serif;
+}
+
+.flag-amber {
+  background-color: #FEAA0280;
+}
+
+.flag-red {
+  background-color: #FF585980;
+}
+
+.flag-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#tocify-header0 {
+  display: none;
+}
+
+
+/* Group summary table -- change cursor to cue to user that tooltip is available */
+td[title] {
+  cursor: help;
+}
+
+tbody.gt_table_body tr:hover:nth-child(odd) {
+  background: #f9f9f9;
+}
+
+#timeline {
+  display: none;
+}
+
+/* Flag Change List Styles */
+.flag-change-list {
+  list-style-type: disc;
+  margin-left: 1.5em;
+}
+.flag-change-parent {
+  margin-bottom: 1em;
+  font-weight: bold;
+  list-style-type: none;
+  position: relative;
+}
+.flag-change-parent::before {
+  content: "+ ";
+  position: absolute;
+  left: -1.2em;
+  font-weight: bold;
+  color: #888;
+}
+.flag-change-parent.expanded::before {
+  content: "\2212 "; /* Unicode minus sign */
+  color: #888;
+}
+.flag-change-nested {
+  list-style-type: circle;
+  margin-left: 2em;
+  display: none;
+}
+.flag-change-parent:not(.expandable)::before {
+  content: none;
+}
+.flag-change-item {
+  margin-bottom: 0.5em;
+  font-weight: normal;
+  list-style-type: none;
+  position: relative;
+}
+.flag-change-item::before {
+  content: "+ ";
+  position: absolute;
+  left: -1.2em;
+  font-weight: bold;
+  color: #888;
+}
+.flag-change-item.expanded::before {
+  content: "\2212 "; /* Unicode minus sign */
+  color: #888;
+}
+.flag-change-details {
+  list-style-type: square;
+  margin-left: 2em;
+  color: #444;
+  font-size: 0.95em;
+  display: none;
+}
+.flag-change-item:not(.expandable)::before {
+  content: none;
+}
+.flag-change-parent:hover, .flag-change-item:hover {
+  background: #f5f5f5;
+  cursor: pointer;
+}
+

--- a/tests/testthat/test-pkgdown-css.R
+++ b/tests/testthat/test-pkgdown-css.R
@@ -2,12 +2,7 @@
 # must be duplicated in pkgdown/extra.css (#240).
 
 test_that("pkgdown/extra.css exists", {
-  extra_css <- system.file("../pkgdown/extra.css", package = "gsm.kri")
-  # system.file returns "" when the path is outside inst/; use file path instead
-  extra_css_path <- file.path(
-    system.file(package = "gsm.kri"),
-    "..", "pkgdown", "extra.css"
-  )
+  extra_css_path <- testthat::test_path("..", "..", "pkgdown", "extra.css")
 
   skip_if_not(file.exists(extra_css_path), "pkgdown/extra.css not found (likely in installed package)")
 

--- a/tests/testthat/test-pkgdown-css.R
+++ b/tests/testthat/test-pkgdown-css.R
@@ -28,8 +28,7 @@ test_that("pkgdown/extra.css exists", {
   )
 })
 
-test_that("pkgdown/extra.css contains all critical rules from inst/report/styles.css", {
-  report_css_path <- system.file("report", "styles.css", package = "gsm.kri")
+test_that("pkgdown/extra.css contains critical selectors", {
   extra_css_path <- file.path(
     system.file(package = "gsm.kri"),
     "..", "pkgdown", "extra.css"

--- a/tests/testthat/test-pkgdown-css.R
+++ b/tests/testthat/test-pkgdown-css.R
@@ -1,0 +1,60 @@
+# pkgdown ignores the css: YAML parameter in menu articles, so report styles
+# must be duplicated in pkgdown/extra.css (#240).
+
+test_that("pkgdown/extra.css exists", {
+  extra_css <- system.file("../pkgdown/extra.css", package = "gsm.kri")
+  # system.file returns "" when the path is outside inst/; use file path instead
+  extra_css_path <- file.path(
+    system.file(package = "gsm.kri"),
+    "..", "pkgdown", "extra.css"
+  )
+
+  skip_if_not(file.exists(extra_css_path), "pkgdown/extra.css not found (likely in installed package)")
+
+  extra_css_content <- readLines(extra_css_path)
+  extra_css_text <- paste(extra_css_content, collapse = "\n")
+
+  expect_match(
+    extra_css_text,
+    "Widget_GroupOverview",
+    fixed = TRUE,
+    label = "extra.css must style Widget_GroupOverview"
+  )
+
+  expect_match(
+    extra_css_text,
+    "height:\\s*auto\\s*!important",
+    label = "extra.css must override widget height to auto"
+  )
+})
+
+test_that("pkgdown/extra.css contains all critical rules from inst/report/styles.css", {
+  report_css_path <- system.file("report", "styles.css", package = "gsm.kri")
+  extra_css_path <- file.path(
+    system.file(package = "gsm.kri"),
+    "..", "pkgdown", "extra.css"
+  )
+
+  skip_if_not(file.exists(extra_css_path), "pkgdown/extra.css not found (likely in installed package)")
+
+  extra_css_text <- paste(readLines(extra_css_path), collapse = "\n")
+
+  # These selectors are critical for correct report rendering on the pkgdown site.
+  critical_selectors <- c(
+    ".Widget_GroupOverview",
+    ".gsm-overview-table",
+    ".overall-group-select",
+    ".flag-container",
+    ".flag-amber",
+    ".flag-red"
+  )
+
+  for (selector in critical_selectors) {
+    expect_match(
+      extra_css_text,
+      selector,
+      fixed = TRUE,
+      label = paste("extra.css must contain selector:", selector)
+    )
+  }
+})

--- a/tests/testthat/test-pkgdown-css.R
+++ b/tests/testthat/test-pkgdown-css.R
@@ -1,7 +1,7 @@
 # pkgdown ignores the css: YAML parameter in menu articles, so report styles
 # must be duplicated in pkgdown/extra.css (#240).
 
-test_that("pkgdown/extra.css exists", {
+test_that("pkgdown/extra.css exists (#240)", {
   extra_css_path <- testthat::test_path("..", "..", "pkgdown", "extra.css")
 
   skip_if_not(file.exists(extra_css_path), "pkgdown/extra.css not found (likely in installed package)")
@@ -23,7 +23,7 @@ test_that("pkgdown/extra.css exists", {
   )
 })
 
-test_that("pkgdown/extra.css contains critical selectors", {
+test_that("pkgdown/extra.css contains critical selectors (#240)", {
   extra_css_path <- file.path(
     system.file(package = "gsm.kri"),
     "..", "pkgdown", "extra.css"


### PR DESCRIPTION
### Summary

Release candidate for gsm.kri v1.5.2. This patch release fixes report display issues on the pkgdown site and renders missing examples.

### Bug Fixes

Fix overlapping report layout on pkgdown site (#240): The css: styles.css YAML parameter in the example Rmd files is ignored by pkgdown, so critical styles (notably .Widget_GroupOverview { height: auto !important; }) were never applied on the published site. This caused the GroupOverview table to overflow its default 400px container and overlap with the overview text below it. Added [extra.css](vscode-file://vscode-app/c:/Users/Laura%20Maxwell/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which pkgdown automatically includes on every page.

Render missing pkgdown examples (#228): Fixes missing example pages on the pkgdown site (#229).

### Testing

Added test-pkgdown-css.R to verify [extra.css](vscode-file://vscode-app/c:/Users/Laura%20Maxwell/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) exists, contains the widget height override, and stays in sync with the critical selectors from [styles.css](vscode-file://vscode-app/c:/Users/Laura%20Maxwell/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

### Changes from dev

This RC branches from main (v1.5.1) and excludes PR #237 (Fix 226: Ignore inactive workflows), which is still pending on dev.