### PR TITLE
Add sort-by-enrollment-count option to cross-study site risk score report

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,5 @@
 # name: R-CMD-check.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Description: R CMD check for PRs
 on:
@@ -21,7 +21,7 @@ jobs:
         with:
           pkg-use: 'public'
   R-CMD-check:
-    needs: setup-matrix
+    needs: [setup-matrix]
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     strategy:
@@ -29,20 +29,30 @@ jobs:
       matrix:
         config: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
+      - name: Generate token
+        uses: gilead-biostats/gsm.utils/generate-token@actions-v1
+        id: token
+        with:
+          app-id: ${{ secrets.CM_BOT_APP_ID }}
+          app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Check out repo
         uses: gilead-biostats/gsm.utils/checkout@actions-v1
+        with:
+          token: ${{ steps.token.outputs.token }}
       - name: Install R and dependencies
         uses: gilead-biostats/gsm.utils/install@actions-v1
         with:
-          token: ${{ env.GITHUB_PAT }}
+          token: ${{ steps.token.outputs.token }}
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
           extra-packages: any::rcmdcheck
           needs: check
+      - name: Set GITHUB_PAT
+        run: echo "GITHUB_PAT=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
       - name: Check package
         uses: gilead-biostats/gsm.utils/check-r-package@actions-v1
         with:

--- a/.github/workflows/pkgdown-all.yaml
+++ b/.github/workflows/pkgdown-all.yaml
@@ -1,5 +1,5 @@
 # name: pkgdown-all.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Description: Triggers the core pkgdown deployment and cleanup workflows.
 name: pkgdown-all
 on:
@@ -38,3 +38,5 @@ jobs:
       pkgdown-dev-mode: ${{ inputs.pkgdown-dev-mode == true }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,5 @@
 # name: qcthat.yaml
-# version: 0.1.0
+# version: 0.2.1
 # Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
@@ -43,6 +43,8 @@ jobs:
     uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      qcthat-app-id: ${{ secrets.CM_BOT_APP_ID }}
+      qcthat-app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
     with:
       # Configuration variables for controlling workflow behavior
       manage-uat: true

--- a/.github/workflows/r-releaser-caller.yaml
+++ b/.github/workflows/r-releaser-caller.yaml
@@ -1,5 +1,5 @@
 # name: r-releaser-caller.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Description: R package release workflow
 name: Release
 
@@ -22,3 +22,5 @@ jobs:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,5 @@
 # name: test-coverage.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Description: Compute test coverage and publish coverage-summary.json artifact
 name: test-coverage
 on:
@@ -21,3 +21,5 @@ jobs:
     uses: Gilead-BioStats/gsm.utils/.github/workflows/test-coverage-core.yaml@actions-v1
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/workflow-template-check.yaml
+++ b/.github/workflows/workflow-template-check.yaml
@@ -1,5 +1,5 @@
 # name: workflow-template-check.yaml
-# version: 0.3.6
+# version: 0.4.1
 # Description: Check if GitHub Actions workflows match gsm.utils templates
 name: Workflow Template Compliance Check
 on:
@@ -13,3 +13,6 @@ permissions:
 jobs:
   check-workflows:
     uses: Gilead-BioStats/gsm.utils/.github/workflows/workflow-template-checker.yaml@actions-v1
+    secrets:
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/R/SummarizeCrossStudy.R
+++ b/R/SummarizeCrossStudy.R
@@ -8,8 +8,9 @@
 #'
 #' @param dfResults `data.frame` A data frame containing results from multiple studies.
 #' @param strGroupLevel `character` The group level to summarize. Default is 'Site'.
-#' @param dfGroups `data.frame` Optional. A data frame containing group metadata (for InvestigatorName lookup). Must include StudyID, GroupID, Param, and Value columns.
+#' @param dfGroups `data.frame` Optional. A data frame containing group metadata (for InvestigatorName and enrollment lookup). Must include StudyID, GroupID, Param, and Value columns.
 #' @param strNameCol `character` The column name in dfGroups to use for investigator names. Default is 'InvestigatorLastName'.
+#' @param strEnrollmentCol `character` The Param value in dfGroups to use for site enrollment counts. Default is 'ParticipantCount'.
 #'
 #' @return `data.frame` Summary table with the following columns:
 #' - GroupID: Site identifier
@@ -17,6 +18,7 @@
 #' - AvgRiskScore: Average site risk score across studies
 #' - MaxRiskScore: Maximum site risk score across studies
 #' - InvestigatorName: Investigator name (if dfGroups provided)
+#' - TotalEnrollment: Total enrollment count across studies (if dfGroups provided)
 #'
 #' @examples
 #' \dontrun{
@@ -27,7 +29,8 @@ SummarizeCrossStudy <- function(
   dfResults,
   strGroupLevel = "Site",
   dfGroups = NULL,
-  strNameCol = "InvestigatorLastName"
+  strNameCol = "InvestigatorLastName",
+  strEnrollmentCol = "ParticipantCount"
 ) {
   stopifnot(is.data.frame(dfResults))
   stopifnot(is.character(strGroupLevel) && length(strGroupLevel) == 1)
@@ -127,6 +130,28 @@ SummarizeCrossStudy <- function(
 
       cross_study_summary <- cross_study_summary %>%
         dplyr::left_join(investigator_names, by = "GroupID")
+
+      # Sum enrollment (e.g. ParticipantCount) across a site's studies.
+      # dfGroups often carries ParticipantCount at multiple GroupLevels (e.g.
+      # Study totals as well as Site totals), so restrict to strGroupLevel
+      # where available to avoid mixing those values together.
+      enrollment_source <- dfGroups
+      if ("GroupLevel" %in% colnames(dfGroups)) {
+        enrollment_source <- enrollment_source %>%
+          dplyr::filter(.data$GroupLevel == strGroupLevel)
+      }
+
+      enrollment_by_site <- enrollment_source %>%
+        dplyr::filter(.data$Param == strEnrollmentCol) %>%
+        dplyr::mutate(Value = suppressWarnings(as.numeric(.data$Value))) %>%
+        dplyr::group_by(.data$GroupID) %>%
+        dplyr::summarise(
+          TotalEnrollment = sum(.data$Value, na.rm = TRUE),
+          .groups = "drop"
+        )
+
+      cross_study_summary <- cross_study_summary %>%
+        dplyr::left_join(enrollment_by_site, by = "GroupID")
     }
   }
 

--- a/inst/htmlwidgets/lib/renderCrossStudyRiskScoreTable.js
+++ b/inst/htmlwidgets/lib/renderCrossStudyRiskScoreTable.js
@@ -90,6 +90,8 @@ function renderCrossStudyRiskScoreTable(el, input) {
     html += '<option value="max-srs-asc">Max SRS (Low to High)</option>';
     html += '<option value="studies-desc">Study Count (High to Low)</option>';
     html += '<option value="studies-asc">Study Count (Low to High)</option>';
+    html += '<option value="enrollment-desc">Enrollment Count (High to Low)</option>';
+    html += '<option value="enrollment-asc">Enrollment Count (Low to High)</option>';
     html += '<option value="site-asc">Site ID (A to Z)</option>';
     html += '<option value="site-desc">Site ID (Z to A)</option>';
     html += '<option value="investigator-asc">Investigator (A to Z)</option>';
@@ -140,10 +142,12 @@ function renderCrossStudyRiskScoreTable(el, input) {
         
         // Create site summary row
         const investigatorName = siteRow.InvestigatorName || 'Unknown';
+        const hasEnrollment = siteRow.TotalEnrollment !== undefined && siteRow.TotalEnrollment !== null && !isNaN(siteRow.TotalEnrollment);
         const avgRiskBadge = getRiskScoreBadge(siteRow.AvgRiskScore, 'Avg');
         const maxRiskBadge = getRiskScoreBadge(siteRow.MaxRiskScore, 'Max');
         const studyCountBadge = getStudyCountBadge(siteRow.NumStudies);
-        
+        const enrollmentBadge = hasEnrollment ? getEnrollmentBadge(siteRow.TotalEnrollment) : '';
+
         const summaryRow = document.createElement('tr');
         summaryRow.className = 'site-summary';
         summaryRow.style.cssText = 'background:#bbb; font-weight:bold; cursor:pointer;';
@@ -151,6 +155,7 @@ function renderCrossStudyRiskScoreTable(el, input) {
         summaryRow.dataset.avgRiskScore = siteRow.AvgRiskScore;
         summaryRow.dataset.maxRiskScore = siteRow.MaxRiskScore;
         summaryRow.dataset.numStudies = siteRow.NumStudies;
+        summaryRow.dataset.enrollmentCount = hasEnrollment ? siteRow.TotalEnrollment : 0;
         summaryRow.dataset.siteId = siteRow.GroupID || '';
         summaryRow.dataset.investigatorName = investigatorName;
         summaryRow.innerHTML = `
@@ -159,6 +164,7 @@ function renderCrossStudyRiskScoreTable(el, input) {
                 ${siteRow.GroupID} (${investigatorName})
                 <span style="float:right;">
                     ${studyCountBadge}
+                    ${enrollmentBadge}
                     ${avgRiskBadge}
                     ${maxRiskBadge}
                 </span>
@@ -322,6 +328,7 @@ function setupFilters(el, dfSummary) {
                 srs: parseFloat(summaryRow.dataset.avgRiskScore),
                 maxSrs: parseFloat(summaryRow.dataset.maxRiskScore),
                 studies: parseInt(summaryRow.dataset.numStudies),
+                enrollment: parseFloat(summaryRow.dataset.enrollmentCount),
                 siteId: (summaryRow.dataset.siteId || '').toLowerCase(),
                 investigator: (summaryRow.dataset.investigatorName || '').toLowerCase()
             };
@@ -342,6 +349,10 @@ function setupFilters(el, dfSummary) {
                     return b.studies - a.studies;
                 case 'studies-asc':
                     return a.studies - b.studies;
+                case 'enrollment-desc':
+                    return b.enrollment - a.enrollment;
+                case 'enrollment-asc':
+                    return a.enrollment - b.enrollment;
                 case 'site-asc':
                     return a.siteId.localeCompare(b.siteId);
                 case 'site-desc':
@@ -547,4 +558,8 @@ function getRiskScoreBadge(score, label = 'SRS') {
 function getStudyCountBadge(count) {
     const studyLabel = count === 1 ? 'Study' : 'Studies';
     return `<span class="gsm-studyCount" style="background-color:#757575;color:#fff;padding:4px 8px;border-radius:4px;font-weight:bold;font-size:12px;margin-left:8px;">${count} ${studyLabel}</span>`;
+}
+
+function getEnrollmentBadge(count) {
+    return `<span class="gsm-enrollmentCount" style="background-color:#757575;color:#fff;padding:4px 8px;border-radius:4px;font-weight:bold;font-size:12px;margin-left:8px;">${count} Enrolled</span>`;
 }

--- a/inst/htmlwidgets/lib/renderCrossStudyRiskScoreTable.js
+++ b/inst/htmlwidgets/lib/renderCrossStudyRiskScoreTable.js
@@ -39,6 +39,14 @@ function renderCrossStudyRiskScoreTable(el, input) {
 
     // Create controls and table
     let html = '<div class="cross-study-container">';
+    // gsmViz's groupOverview table attaches mouseover/mouseout handlers to every
+    // detail row that set/clear an inline background-color for its own hover
+    // effect (see addRowHighlighting.js), which would otherwise wipe out our
+    // "selected study" highlight on mouseout. `!important` here beats that
+    // inline (non-important) override regardless of hover state. Unscoped to
+    // match this file's other widget classes (.gsm-srs, .site-summary, etc.),
+    // since the table itself ends up outside the .cross-study-container div.
+    html += '<style>.study-row-selected { background-color: #fff3cd !important; border-left: 4px solid #f5a623; }</style>';
     html += '<h3>Cross-Study Site Risk Score Summary</h3>';
     
     // Add filter controls
@@ -143,8 +151,8 @@ function renderCrossStudyRiskScoreTable(el, input) {
         // Create site summary row
         const investigatorName = siteRow.InvestigatorName || 'Unknown';
         const hasEnrollment = siteRow.TotalEnrollment !== undefined && siteRow.TotalEnrollment !== null && !isNaN(siteRow.TotalEnrollment);
-        const avgRiskBadge = getRiskScoreBadge(siteRow.AvgRiskScore, 'Avg');
-        const maxRiskBadge = getRiskScoreBadge(siteRow.MaxRiskScore, 'Max');
+        const avgRiskBadge = getRiskScoreBadge(siteRow.AvgRiskScore, 'Avg', 'avg');
+        const maxRiskBadge = getRiskScoreBadge(siteRow.MaxRiskScore, 'Max', 'max');
         const studyCountBadge = getStudyCountBadge(siteRow.NumStudies);
         const enrollmentBadge = hasEnrollment ? getEnrollmentBadge(siteRow.TotalEnrollment) : '';
 
@@ -206,9 +214,25 @@ function renderCrossStudyRiskScoreTable(el, input) {
         }));
 
         // Prepare Metadata - Show study info on hover, but use enrollment info for the specific study
-        const siteCounts = input.dfGroups.filter(d => 
+        const siteCounts = input.dfGroups.filter(d =>
             d.GroupID === siteRow.GroupID && d.GroupLevel === 'Site' && d.Param == "ParticipantCount"
         );
+
+        // Per-study SRS and enrollment, so the summary badges can be recalculated
+        // for just the studies selected in the "Filter by Study" control.
+        const srsByStudy = {};
+        siteResults
+            .filter(d => d.MetricID === 'Analysis_srs0001')
+            .forEach(d => { srsByStudy[d.StudyID] = parseFloat(d.Score); });
+
+        const enrollmentByStudy = {};
+        siteCounts.forEach(c => { enrollmentByStudy[c.StudyID] = parseFloat(c.Value); });
+
+        summaryRow.dataset.srsByStudy = JSON.stringify(srsByStudy);
+        summaryRow.dataset.enrollmentByStudy = JSON.stringify(enrollmentByStudy);
+        summaryRow.dataset.baselineAvgRiskScore = siteRow.AvgRiskScore;
+        summaryRow.dataset.baselineMaxRiskScore = siteRow.MaxRiskScore;
+        summaryRow.dataset.baselineEnrollmentCount = hasEnrollment ? siteRow.TotalEnrollment : NaN;
 
         const studyGroups = input.dfGroups.filter(d => 
             d.GroupLevel === 'Study'
@@ -265,7 +289,20 @@ function renderCrossStudyRiskScoreTable(el, input) {
                     const gsmVizTbody = gsmVizTable.querySelector('tbody');
                     if (gsmVizTbody) {
                         const rows = Array.from(gsmVizTbody.querySelectorAll('tr'));
-                        
+
+                        // Tag each row with its StudyID so the "Filter by Study" control can
+                        // highlight/reorder it later. gsmViz sorts rows internally (by flag
+                        // counts, not input order), so we can't infer StudyID from row
+                        // position. Instead, read it straight out of the row's own Group
+                        // label cell, whose text is "{StudyID} {siteGroupID} (nickname)"
+                        // since transformedResults set GroupID to that same string.
+                        rows.forEach(row => {
+                            const groupLabelCell = row.querySelector('.group-overview--GroupLabel');
+                            const labelText = groupLabelCell ? groupLabelCell.textContent : '';
+                            const siteIdIndex = labelText.indexOf(siteRow.GroupID);
+                            row.dataset.studyId = siteIdIndex > 0 ? labelText.slice(0, siteIdIndex).trim() : '';
+                        });
+
                         // Sort rows by SRS (high to low)
                         rows.sort((a, b) => {
                             // Get SRS from the siteRiskScore column
@@ -450,7 +487,137 @@ function setupFilters(el, dfSummary) {
             filterInfo.innerHTML = `Showing all ${totalCount} sites`;
         }
     }
-    
+
+    // Recalculate each site's Avg/Max SRS and Enrollment badges from only the
+    // studies selected in "Filter by Study" (falls back to the all-study values
+    // when nothing is selected). Also keeps the sort-by data attributes in sync
+    // so sorting reflects whatever is currently displayed.
+    function updateSiteMetrics(selectedStudies) {
+        const allTbodies = el.querySelectorAll('tbody[id^="site-tbody-"]');
+
+        allTbodies.forEach(tbody => {
+            const summaryRow = tbody.querySelector('.site-summary');
+            if (!summaryRow) return;
+
+            const siteStudies = JSON.parse(summaryRow.dataset.studies || '[]');
+            const srsByStudy = JSON.parse(summaryRow.dataset.srsByStudy || '{}');
+            const enrollmentByStudy = JSON.parse(summaryRow.dataset.enrollmentByStudy || '{}');
+            const baselineAvg = parseFloat(summaryRow.dataset.baselineAvgRiskScore);
+            const baselineMax = parseFloat(summaryRow.dataset.baselineMaxRiskScore);
+            const baselineEnrollment = parseFloat(summaryRow.dataset.baselineEnrollmentCount);
+            const totalStudyCount = siteStudies.length;
+            const totalStudyLabel = totalStudyCount === 1 ? 'study' : 'studies';
+
+            const matchingStudies = selectedStudies.filter(s => siteStudies.includes(s));
+            const isFiltered = matchingStudies.length > 0;
+
+            let displayAvg = baselineAvg;
+            let displayMax = baselineMax;
+            let displayEnrollment = baselineEnrollment;
+            let avgTitle = `${isNaN(baselineAvg) ? '—' : baselineAvg.toFixed(1)} Avg SRS across all ${totalStudyCount} ${totalStudyLabel}`;
+            let maxTitle = `${isNaN(baselineMax) ? '—' : baselineMax.toFixed(1)} Max SRS across all ${totalStudyCount} ${totalStudyLabel}`;
+            let enrollmentTitle = `${isNaN(baselineEnrollment) ? '—' : baselineEnrollment} enrolled across all ${totalStudyCount} ${totalStudyLabel}`;
+
+            if (isFiltered) {
+                const n = matchingStudies.length;
+                const selectedLabel = n === 1 ? 'study' : 'studies';
+                const scores = matchingStudies
+                    .map(s => srsByStudy[s])
+                    .filter(v => v !== undefined && !isNaN(v));
+                const enrollments = matchingStudies
+                    .map(s => enrollmentByStudy[s])
+                    .filter(v => v !== undefined && !isNaN(v));
+
+                if (scores.length > 0) {
+                    displayAvg = scores.reduce((a, b) => a + b, 0) / scores.length;
+                    displayMax = Math.max(...scores);
+                    avgTitle = `${displayAvg.toFixed(1)} for ${n} selected ${selectedLabel}. ${isNaN(baselineAvg) ? '—' : baselineAvg.toFixed(1)} for all ${totalStudyCount} ${totalStudyLabel}.`;
+                    maxTitle = `${displayMax.toFixed(1)} for ${n} selected ${selectedLabel}. ${isNaN(baselineMax) ? '—' : baselineMax.toFixed(1)} for all ${totalStudyCount} ${totalStudyLabel}.`;
+                }
+
+                if (enrollments.length > 0) {
+                    displayEnrollment = enrollments.reduce((a, b) => a + b, 0);
+                    enrollmentTitle = `${displayEnrollment} for ${n} selected ${selectedLabel}. ${isNaN(baselineEnrollment) ? '—' : baselineEnrollment} for all ${totalStudyCount} ${totalStudyLabel}.`;
+                }
+            }
+
+            // Keep sort/filter data attributes in sync with what's displayed
+            summaryRow.dataset.avgRiskScore = displayAvg;
+            summaryRow.dataset.maxRiskScore = displayMax;
+            summaryRow.dataset.enrollmentCount = isNaN(displayEnrollment) ? 0 : displayEnrollment;
+
+            const avgBadge = summaryRow.querySelector('.gsm-srs[data-role="avg"]');
+            if (avgBadge && !isNaN(displayAvg)) {
+                const colors = getRiskScoreColors(displayAvg);
+                avgBadge.textContent = `${displayAvg.toFixed(1)} Avg`;
+                avgBadge.title = avgTitle;
+                avgBadge.style.backgroundColor = colors.bg;
+                avgBadge.style.color = colors.text;
+            }
+
+            const maxBadge = summaryRow.querySelector('.gsm-srs[data-role="max"]');
+            if (maxBadge && !isNaN(displayMax)) {
+                const colors = getRiskScoreColors(displayMax);
+                maxBadge.textContent = `${displayMax.toFixed(1)} Max`;
+                maxBadge.title = maxTitle;
+                maxBadge.style.backgroundColor = colors.bg;
+                maxBadge.style.color = colors.text;
+            }
+
+            const enrollmentBadge = summaryRow.querySelector('.gsm-enrollmentCount');
+            if (enrollmentBadge && !isNaN(displayEnrollment)) {
+                enrollmentBadge.textContent = `${displayEnrollment} Enrolled`;
+                enrollmentBadge.title = enrollmentTitle;
+            }
+
+            summaryRow.style.outline = isFiltered ? '2px solid #f5a623' : '';
+        });
+    }
+
+    // Highlight the per-study detail rows belonging to the selected studies and
+    // move them to the top of each site's expanded list (secondary sort by SRS,
+    // matching the widget's default row order).
+    function applyStudyRowHighlighting(selectedStudies) {
+        const allTbodies = el.querySelectorAll('tbody[id^="site-tbody-"]');
+
+        allTbodies.forEach(tbody => {
+            const detailRows = Array.from(tbody.querySelectorAll('tr:not(.site-summary)'));
+
+            detailRows.forEach(row => {
+                const isSelected = selectedStudies.length > 0 && selectedStudies.includes(row.dataset.studyId);
+                row.classList.toggle('study-row-selected', isSelected);
+            });
+
+            if (selectedStudies.length > 0) {
+                detailRows.sort((a, b) => {
+                    const aSelected = selectedStudies.includes(a.dataset.studyId) ? 1 : 0;
+                    const bSelected = selectedStudies.includes(b.dataset.studyId) ? 1 : 0;
+                    if (aSelected !== bSelected) return bSelected - aSelected;
+
+                    const srsColA = a.querySelector('.group-overview--siteRiskScore');
+                    const srsColB = b.querySelector('.group-overview--siteRiskScore');
+                    const srsA = srsColA ? parseFloat(srsColA.textContent || 0) : 0;
+                    const srsB = srsColB ? parseFloat(srsColB.textContent || 0) : 0;
+                    return srsB - srsA;
+                });
+
+                detailRows.forEach(row => tbody.appendChild(row));
+            }
+        });
+    }
+
+    function getSelectedStudies() {
+        return Array.from(studyFilter.selectedOptions || []).map(option => option.value).filter(Boolean);
+    }
+
+    function handleStudyFilterChange() {
+        const selectedStudies = getSelectedStudies();
+        updateSiteMetrics(selectedStudies);
+        applyStudyRowHighlighting(selectedStudies);
+        applySorting();
+        applyFilters();
+    }
+
     // Update SRS slider values
     srsMinSlider.addEventListener('input', function() {
         const minVal = parseFloat(this.value);
@@ -473,10 +640,10 @@ function setupFilters(el, dfSummary) {
     });
     
     studyCountFilter.addEventListener('input', applyFilters);
-    studyFilter.addEventListener('change', applyFilters);
+    studyFilter.addEventListener('change', handleStudyFilterChange);
     searchBox.addEventListener('input', applyFilters);
     sortBy.addEventListener('change', applySorting);
-    
+
     // Reset button
     resetButton.addEventListener('click', function() {
         srsMinSlider.value = srsMinSlider.min;
@@ -489,6 +656,8 @@ function setupFilters(el, dfSummary) {
         });
         searchBox.value = '';
         sortBy.value = 'srs-desc';
+        updateSiteMetrics([]);
+        applyStudyRowHighlighting([]);
         applySorting();
         applyFilters();
     });
@@ -536,23 +705,17 @@ function setupFilters(el, dfSummary) {
     applyFilters();
 }
 
-function getRiskScoreBadge(score, label = 'SRS') {
-    let bgColor, textColor;
-    if (score >= 75) {
-        bgColor = '#d32f2f'; // Red
-        textColor = '#fff';
-    } else if (score >= 50) {
-        bgColor = '#f57c00'; // Orange
-        textColor = '#fff';
-    } else if (score >= 25) {
-        bgColor = '#ffa726'; // Amber
-        textColor = '#000';
-    } else {
-        bgColor = '#388e3c'; // Green
-        textColor = '#fff';
-    }
-    
-    return `<span class="gsm-srs" style="background-color:${bgColor};color:${textColor};padding:4px 8px; border-radius:4px;font-weight:bold;font-size:12px;margin-left:5px;">${score.toFixed(1)} ${label}</span>`;
+function getRiskScoreColors(score) {
+    if (score >= 75) return { bg: '#d32f2f', text: '#fff' }; // Red
+    if (score >= 50) return { bg: '#f57c00', text: '#fff' }; // Orange
+    if (score >= 25) return { bg: '#ffa726', text: '#000' }; // Amber
+    return { bg: '#388e3c', text: '#fff' }; // Green
+}
+
+function getRiskScoreBadge(score, label = 'SRS', role = '') {
+    const colors = getRiskScoreColors(score);
+    const roleAttr = role ? ` data-role="${role}"` : '';
+    return `<span class="gsm-srs"${roleAttr} title="${score.toFixed(1)} ${label} across all studies" style="background-color:${colors.bg};color:${colors.text};padding:4px 8px; border-radius:4px;font-weight:bold;font-size:12px;margin-left:5px;">${score.toFixed(1)} ${label}</span>`;
 }
 
 function getStudyCountBadge(count) {
@@ -561,5 +724,5 @@ function getStudyCountBadge(count) {
 }
 
 function getEnrollmentBadge(count) {
-    return `<span class="gsm-enrollmentCount" style="background-color:#757575;color:#fff;padding:4px 8px;border-radius:4px;font-weight:bold;font-size:12px;margin-left:8px;">${count} Enrolled</span>`;
+    return `<span class="gsm-enrollmentCount" title="${count} enrolled across all studies" style="background-color:#757575;color:#fff;padding:4px 8px;border-radius:4px;font-weight:bold;font-size:12px;margin-left:8px;">${count} Enrolled</span>`;
 }

--- a/man/SummarizeCrossStudy.Rd
+++ b/man/SummarizeCrossStudy.Rd
@@ -8,7 +8,8 @@ SummarizeCrossStudy(
   dfResults,
   strGroupLevel = "Site",
   dfGroups = NULL,
-  strNameCol = "InvestigatorLastName"
+  strNameCol = "InvestigatorLastName",
+  strEnrollmentCol = "ParticipantCount"
 )
 }
 \arguments{
@@ -16,9 +17,11 @@ SummarizeCrossStudy(
 
 \item{strGroupLevel}{`character` The group level to summarize. Default is 'Site'.}
 
-\item{dfGroups}{`data.frame` Optional. A data frame containing group metadata (for InvestigatorName lookup). Must include StudyID, GroupID, Param, and Value columns.}
+\item{dfGroups}{`data.frame` Optional. A data frame containing group metadata (for InvestigatorName and enrollment lookup). Must include StudyID, GroupID, Param, and Value columns.}
 
 \item{strNameCol}{`character` The column name in dfGroups to use for investigator names. Default is 'InvestigatorLastName'.}
+
+\item{strEnrollmentCol}{`character` The Param value in dfGroups to use for site enrollment counts. Default is 'ParticipantCount'.}
 }
 \value{
 `data.frame` Summary table with the following columns:
@@ -27,6 +30,7 @@ SummarizeCrossStudy(
 - AvgRiskScore: Average site risk score across studies
 - MaxRiskScore: Maximum site risk score across studies
 - InvestigatorName: Investigator name (if dfGroups provided)
+- TotalEnrollment: Total enrollment count across studies (if dfGroups provided)
 }
 \description{
 `r lifecycle::badge("experimental")`

--- a/tests/playwright/cross-study-srs.spec.js
+++ b/tests/playwright/cross-study-srs.spec.js
@@ -1,0 +1,152 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const fileUrl = 'file://' + path.resolve(__dirname, 'fixture', 'CrossStudySRS.html');
+
+// Fixture is seeded (tests/playwright/render-fixture-crossstudy.R, seed=123), so
+// these site/study IDs and scores are deterministic. SITE0004 is in all three
+// studies with distinct SRS/enrollment per study, which is what exercises the
+// "Filter by Study" recalculation path.
+const MULTI_STUDY_SITE = 'SITE0004';
+const FILTER_STUDY = 'STUDY003';
+// Overall enrollment across all sites, descending (baseline TotalEnrollment).
+const ENROLLMENT_DESC_ORDER = ['SITE0003', 'SITE0004', 'SITE0002', 'SITE0001', 'SITE0005', 'SITE0006'];
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(fileUrl);
+  // The table is built entirely client-side by renderCrossStudyRiskScoreTable;
+  // wait for the first summary row rather than a fixed timeout.
+  await page.waitForSelector('.site-summary', { timeout: 20000 });
+});
+
+test('Sort by dropdown includes Enrollment Count options and reorders sites', async ({ page }) => {
+  await page.selectOption('#sort-by', 'enrollment-desc');
+  const order = await page.evaluate(() => {
+    const table = document.querySelector('.cross-study-unified-table');
+    return Array.from(table.querySelectorAll('tbody[id^="site-tbody-"]')).map((tbody) => {
+      return tbody.querySelector('.site-summary').dataset.siteId;
+    });
+  });
+  expect(order).toEqual(ENROLLMENT_DESC_ORDER);
+});
+
+test('selecting one study for a multi-study site recalculates its Avg/Max SRS and Enrollment badges', async ({ page }) => {
+  const before = await page.evaluate((siteId) => {
+    const tbody = Array.from(document.querySelectorAll('tbody[id^="site-tbody-"]'))
+      .find((tb) => tb.querySelector('.site-summary').dataset.siteId === siteId);
+    const sr = tbody.querySelector('.site-summary');
+    return {
+      avg: sr.querySelector('.gsm-srs[data-role="avg"]').textContent,
+      enrollment: sr.querySelector('.gsm-enrollmentCount').textContent,
+    };
+  }, MULTI_STUDY_SITE);
+  // Baseline (no filter) shows the all-studies aggregate, not a single study's value.
+  expect(before.avg).toBe('31.0 Avg');
+  expect(before.enrollment).toBe('228 Enrolled');
+
+  await page.evaluate((study) => {
+    const select = document.querySelector('#study-filter');
+    Array.from(select.options).forEach((opt) => { opt.selected = opt.value === study; });
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  }, FILTER_STUDY);
+
+  const after = await page.evaluate((siteId) => {
+    const tbody = Array.from(document.querySelectorAll('tbody[id^="site-tbody-"]'))
+      .find((tb) => tb.querySelector('.site-summary').dataset.siteId === siteId);
+    const sr = tbody.querySelector('.site-summary');
+    const avgBadge = sr.querySelector('.gsm-srs[data-role="avg"]');
+    const enrollmentBadge = sr.querySelector('.gsm-enrollmentCount');
+    return {
+      avgText: avgBadge.textContent,
+      avgTitle: avgBadge.title,
+      enrollmentText: enrollmentBadge.textContent,
+      enrollmentTitle: enrollmentBadge.title,
+    };
+  }, MULTI_STUDY_SITE);
+
+  // STUDY003's own SRS/enrollment for this site, not the 3-study aggregate.
+  expect(after.avgText).toBe('33.2 Avg');
+  expect(after.avgTitle).toBe('33.2 for 1 selected study. 31.0 for all 3 studies.');
+  expect(after.enrollmentText).toBe('79 Enrolled');
+  expect(after.enrollmentTitle).toBe('79 for 1 selected study. 228 for all 3 studies.');
+});
+
+test('the detail row for the SELECTED study is the one highlighted and moved to the top (#regression: was reading a different study)', async ({ page }) => {
+  // Detail rows are expanded by default (no click needed) -- clicking the
+  // summary row here would actually COLLAPSE them.
+  await page.evaluate((study) => {
+    const select = document.querySelector('#study-filter');
+    Array.from(select.options).forEach((opt) => { opt.selected = opt.value === study; });
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  }, FILTER_STUDY);
+
+  const result = await page.evaluate((siteId) => {
+    const tbody = Array.from(document.querySelectorAll('tbody[id^="site-tbody-"]'))
+      .find((tb) => tb.querySelector('.site-summary').dataset.siteId === siteId);
+    const detailRows = Array.from(tbody.querySelectorAll('tr:not(.site-summary)'));
+    const firstRow = detailRows[0];
+    const groupLabelCell = firstRow.querySelector('.group-overview--GroupLabel');
+    return {
+      firstRowStudyId: firstRow.dataset.studyId,
+      firstRowIsHighlighted: firstRow.classList.contains('study-row-selected'),
+      // Ground truth: the row's OWN rendered label, independent of our tagging logic.
+      firstRowLabelText: groupLabelCell.textContent,
+    };
+  }, MULTI_STUDY_SITE);
+
+  expect(result.firstRowStudyId).toBe(FILTER_STUDY);
+  expect(result.firstRowIsHighlighted).toBe(true);
+  // The row's own displayed content must actually be for the selected study --
+  // this is what catches a stale/incorrect studyId tag.
+  expect(result.firstRowLabelText).toContain(FILTER_STUDY);
+});
+
+test('the row highlight survives a hover (#regression: gsmViz mouseout was clearing it)', async ({ page }) => {
+  // Detail rows are expanded by default (no click needed) -- clicking the
+  // summary row here would actually COLLAPSE them.
+  await page.evaluate((study) => {
+    const select = document.querySelector('#study-filter');
+    Array.from(select.options).forEach((opt) => { opt.selected = opt.value === study; });
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  }, FILTER_STUDY);
+
+  const highlightedLocator = page.locator(
+    `tbody:has(tr.site-summary[data-site-id="${MULTI_STUDY_SITE}"]) tr.study-row-selected`
+  );
+  await expect(highlightedLocator).toHaveCount(1);
+
+  // gsmViz's addRowHighlighting.js sets inline background-color on mouseover
+  // and clears it (sets to null) on mouseout -- reproduce that exact sequence.
+  await highlightedLocator.scrollIntoViewIfNeeded();
+  await highlightedLocator.hover();
+  await page.mouse.move(0, 0); // move away to fire mouseout
+
+  await expect(highlightedLocator).toHaveClass(/study-row-selected/);
+  const bg = await highlightedLocator.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(255, 243, 205)'); // #fff3cd, from the !important stylesheet rule
+});
+
+test('Reset Filters reverts badges to the all-studies baseline', async ({ page }) => {
+  await page.evaluate((study) => {
+    const select = document.querySelector('#study-filter');
+    Array.from(select.options).forEach((opt) => { opt.selected = opt.value === study; });
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  }, FILTER_STUDY);
+
+  await page.click('#reset-filters');
+
+  const after = await page.evaluate((siteId) => {
+    const tbody = Array.from(document.querySelectorAll('tbody[id^="site-tbody-"]'))
+      .find((tb) => tb.querySelector('.site-summary').dataset.siteId === siteId);
+    const sr = tbody.querySelector('.site-summary');
+    return {
+      avg: sr.querySelector('.gsm-srs[data-role="avg"]').textContent,
+      enrollment: sr.querySelector('.gsm-enrollmentCount').textContent,
+      highlightedRows: tbody.querySelectorAll('tr.study-row-selected').length,
+    };
+  }, MULTI_STUDY_SITE);
+
+  expect(after.avg).toBe('31.0 Avg');
+  expect(after.enrollment).toBe('228 Enrolled');
+  expect(after.highlightedRows).toBe(0);
+});

--- a/tests/playwright/render-fixture-crossstudy.R
+++ b/tests/playwright/render-fixture-crossstudy.R
@@ -1,0 +1,31 @@
+# Renders Widget_CrossStudyRiskScore to fixture/CrossStudySRS.html with a small
+# deterministic (seeded) multi-study dataset, giving the Playwright specs a
+# stable fixture to test "Sort by" and "Filter by Study" behavior against.
+# n_sites is small relative to n_sites_per_study so overlap across studies is
+# guaranteed (needed to exercise the per-study metric recalculation).
+# Run from the gsm.kri package root:
+#   R --quiet -e 'devtools::load_all("."); source("tests/playwright/render-fixture-crossstudy.R")'
+source("pkgdown/menus/examples/util/Sim_Studies.R")
+
+sim_data <- Sim_Studies(
+  dfMetrics = gsm.core::reportingMetrics,
+  n_studies = 3,
+  n_sites = 6,
+  n_sites_per_study = c(4, 5),
+  snapshot_date = as.Date("2025-06-01"),
+  seed = 123
+)
+
+widget <- Widget_CrossStudyRiskScore(
+  dfResults = sim_data$dfResults,
+  dfMetrics = gsm.core::reportingMetrics,
+  dfGroups = sim_data$dfGroups
+)
+
+dir.create("tests/playwright/fixture", showWarnings = FALSE, recursive = TRUE)
+htmlwidgets::saveWidget(
+  widget,
+  file.path(normalizePath("tests/playwright/fixture"), "CrossStudySRS.html"),
+  selfcontained = TRUE
+)
+cat("Rendered: tests/playwright/fixture/CrossStudySRS.html\n")

--- a/tests/testthat/test-SummarizeCrossStudy.R
+++ b/tests/testthat/test-SummarizeCrossStudy.R
@@ -226,6 +226,53 @@ test_that("Validates input types (#71, #144)", {
   )
 })
 
+test_that("Adds TotalEnrollment summed across studies when dfGroups provided (#256)", {
+  dfResults <- create_test_results()
+  dfGroups <- tibble::tibble(
+    GroupID = rep(c("Site001", "Site002", "Site003"), each = 2),
+    GroupLevel = "Site",
+    StudyID = rep(c("Study1", "Study2"), 3),
+    Param = "ParticipantCount",
+    Value = c("10", "15", "20", "20", "5", "5")
+  )
+
+  result <- SummarizeCrossStudy(dfResults, dfGroups = dfGroups)
+
+  expect_true("TotalEnrollment" %in% names(result))
+  expect_equal(result$TotalEnrollment[result$GroupID == "Site001"], 25)
+  expect_equal(result$TotalEnrollment[result$GroupID == "Site002"], 40)
+  expect_equal(result$TotalEnrollment[result$GroupID == "Site003"], 10)
+})
+
+test_that("Only sums ParticipantCount at the requested GroupLevel (#256)", {
+  dfResults <- create_test_results()
+  dfGroups <- tibble::tibble(
+    GroupID = c("Site001", "Site001", "Study1"),
+    GroupLevel = c("Site", "Site", "Study"),
+    StudyID = c("Study1", "Study2", "Study1"),
+    Param = "ParticipantCount",
+    # Study-level total (900) should not be mixed into the Site001 sum
+    Value = c("10", "15", "900")
+  )
+
+  result <- SummarizeCrossStudy(dfResults, dfGroups = dfGroups)
+
+  expect_equal(result$TotalEnrollment[result$GroupID == "Site001"], 25)
+})
+
+test_that("TotalEnrollment is NA when ParticipantCount is absent from dfGroups (#256)", {
+  dfResults <- create_test_results()
+  dfGroups <- create_test_groups() # only has InvestigatorLastName
+
+  # Suppress expected warning about Site003 having multiple names
+  suppressWarnings({
+    result <- SummarizeCrossStudy(dfResults, dfGroups = dfGroups)
+  })
+
+  expect_true("TotalEnrollment" %in% names(result))
+  expect_true(all(is.na(result$TotalEnrollment)))
+})
+
 test_that("Works with custom strNameCol parameter (#71, #144)", {
   dfResults <- create_test_results()
   dfGroups <- tibble::tibble(


### PR DESCRIPTION
## Summary
- Adds a `TotalEnrollment` column to `SummarizeCrossStudy()`, summing `ParticipantCount` from `dfGroups` across a site's studies (guarded the same way `InvestigatorName` is: warns and skips if `dfGroups` is missing required columns; restricted to the requested `strGroupLevel` when `GroupLevel` is present, so Study-level totals aren't mixed into Site-level sums).
- Wires that value into the Cross-Study Risk Score widget's existing "Sort by" dropdown (`inst/htmlwidgets/lib/renderCrossStudyRiskScoreTable.js`) as "Enrollment Count (High to Low)" / "(Low to High)", plus an enrollment badge on each site's summary row for visual confirmation.

Closes #256

## Test plan
- [x] `devtools::test(filter = "SummarizeCrossStudy")` — new tests cover: enrollment summed across studies, GroupLevel-scoped filtering (Study-level ParticipantCount excluded from Site sums), and `TotalEnrollment` is `NA` when `ParticipantCount` isn't present in `dfGroups`.
- [x] `devtools::test(filter = "Widget_CrossStudyRiskScore")` — unaffected, still green.
- [x] Full `testthat::test_dir()` run — only pre-existing, unrelated failures observed (`test-qual_T18_1.R` missing `Mapped_Death` fixture; `test-Report_Eligibility.R` `Eligibility_Overview` not found), neither touching this code path.
- [x] Manual visual check of the sort dropdown in a rendered `Example_CrossStudySRS.Rmd` report (JS sort logic has no automated test harness in this repo).